### PR TITLE
Refactor core internals: profiler, tracked(), For component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,21 +14,17 @@ Supergrain is a reactive store library with fine-grained reactivity. The project
 
 ## Required Commands After Code Changes
 
-**IMPORTANT**: After making any code changes, you MUST run both tests and type checks:
-
-### 1. Run Tests
+**IMPORTANT**: After making any code changes, you MUST run ALL of the following checks. These mirror exactly what CI runs — if any fail locally, CI will fail too.
 
 ```bash
-pnpm test
+pnpm test              # Unit tests across all packages
+pnpm run test:validate # README/docs documentation validation
+pnpm run typecheck     # TypeScript type checking across all packages
+pnpm lint              # Linting across all packages
+pnpm format            # Formatting (oxfmt)
 ```
 
-### 2. Run Type Checks
-
-```bash
-pnpm run typecheck
-```
-
-Both commands must pass before considering any code changes complete.
+**All five commands must pass before pushing or considering any code changes complete.** Do NOT skip `test:validate` — it catches orphaned doc tests and missing DOC_TEST identifiers.
 
 ## Package-specific Commands
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -28,6 +28,11 @@ export function unwrap<T>(value: T): T {
   return (value && (value as any)[$RAW]) || value;
 }
 
+/** Get nodes if they already exist (no creation). Fast path for hot loops. */
+export function getNodesIfExist(target: object): DataNodes | undefined {
+  return (target as any)[$NODE];
+}
+
 export function getNodes(target: object): DataNodes {
   let nodes = (target as any)[$NODE];
   if (!nodes) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,6 @@ export {
   disableProfiling,
   resetProfiler,
   getProfile,
-  profileEffectFire,
   profileTimeStart,
   profileTimeEnd,
   type Profile,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 // Export the optimized implementation
 export { createStore, unwrap, $BRAND, type Signal, type Branded } from "./store";
+export { getNodesIfExist } from "./core";
 
 // Export MongoDB-style update operators
 export {
@@ -25,5 +26,9 @@ export {
   disableProfiling,
   resetProfiler,
   getProfile,
+  profileEffectFire,
+  profileTimeStart,
+  profileTimeEnd,
   type Profile,
+  type TimingBucket,
 } from "./profiler";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 // Export the optimized implementation
 export { createStore, unwrap, $BRAND, type Signal, type Branded } from "./store";
-export { getNodesIfExist } from "./core";
+export { getNodesIfExist, $TRACK } from "./core";
 
 // Export MongoDB-style update operators
 export {
@@ -18,6 +18,7 @@ export {
   endBatch,
   getCurrentSub,
   setCurrentSub,
+  type ReactiveNode,
 } from "alien-signals";
 
 export { profiledEffect as effect } from "./profiler";

--- a/packages/core/src/operators.ts
+++ b/packages/core/src/operators.ts
@@ -1,6 +1,6 @@
 import { startBatch, endBatch } from "alien-signals";
 
-import { $NODE, unwrap } from "./core";
+import { unwrap, getNodesIfExist } from "./core";
 import {
   type ArrayPullOperations,
   type ArrayWriteOperations,
@@ -168,7 +168,7 @@ function pullFromArray(arr: any[], condition: any): boolean {
   if (removed && arr.length !== originalLength) {
     bumpVersion(arr);
 
-    const nodes = (arr as any)[$NODE];
+    const nodes = getNodesIfExist(arr);
     if (nodes) {
       bumpOwnKeysSignal(arr, nodes);
 

--- a/packages/core/src/profiler.ts
+++ b/packages/core/src/profiler.ts
@@ -21,12 +21,10 @@ export type TimingBucket =
   | "computedAlloc"
   | "computedEval"
   | "forRender"
-  | "forTotalRenderTime"
   | "forSlotBuildTime"
   | "forSwapEffect"
   | "forArrayCopy"
   | "signalSubscribe"
-  | "proxyGetTime"
   | "wrapTime"
   | "setPropertyTime"
   | "signalBumpTime"
@@ -61,12 +59,10 @@ const _timings: Record<TimingBucket, number> = {
   computedAlloc: 0,
   computedEval: 0,
   forRender: 0,
-  forTotalRenderTime: 0,
   forSlotBuildTime: 0,
   forSwapEffect: 0,
   forArrayCopy: 0,
   signalSubscribe: 0,
-  proxyGetTime: 0,
   wrapTime: 0,
   setPropertyTime: 0,
   signalBumpTime: 0,
@@ -87,6 +83,10 @@ export function profileSignalWrite(): void {
 export function profileEffectFire(): void {
   if (_enabled) _effectFires++;
 }
+/**
+ * Start timing a named bucket. Not reentrant — nested calls to the same
+ * bucket (e.g., nested For components) will overwrite the outer start time.
+ */
 export function profileTimeStart(bucket: TimingBucket): void {
   if (_enabled) _timingStarts[bucket] = performance.now();
 }

--- a/packages/core/src/profiler.ts
+++ b/packages/core/src/profiler.ts
@@ -25,7 +25,6 @@ export type TimingBucket =
   | "forSwapEffect"
   | "forArrayCopy"
   | "signalSubscribe"
-  | "proxyGetTime"
   | "wrapTime"
   | "setPropertyTime"
   | "signalBumpTime"
@@ -64,7 +63,6 @@ const _timings: Record<TimingBucket, number> = {
   forSwapEffect: 0,
   forArrayCopy: 0,
   signalSubscribe: 0,
-  proxyGetTime: 0,
   wrapTime: 0,
   setPropertyTime: 0,
   signalBumpTime: 0,

--- a/packages/core/src/profiler.ts
+++ b/packages/core/src/profiler.ts
@@ -1,22 +1,36 @@
 /**
  * Lightweight profiler for diagnosing signal subscription and render behavior.
  *
- * Zero cost when disabled — profiling functions are swapped to empty no-ops
- * that V8 inlines away. No boolean checks on the hot path.
- * Enable with `enableProfiling()`, read with `getProfile()`, reset with `resetProfiler()`.
+ * Zero cost when disabled — all profiling functions check a single boolean
+ * that V8 branch-predicts as false. The functions themselves are constant
+ * (not swapped via mutable let bindings) so V8 can inline them.
  *
- * @example
- * ```ts
- * enableProfiling();
- * resetProfiler();
- * update();
- * const p = getProfile();
- * expect(p.effectFires).toBe(100); // 100 rows re-rendered
- * disableProfiling();
- * ```
+ * Enable with `enableProfiling()`, read with `getProfile()`, reset with `resetProfiler()`.
  */
 
 import { effect as alienEffect } from "alien-signals";
+
+/** Named timing buckets for profiling where time is spent. */
+export type TimingBucket =
+  | "trackedSetup"
+  | "trackedHookTime"
+  | "trackedEffectTime"
+  | "trackedRenderTime"
+  | "effectCleanupTime"
+  | "computedSetup"
+  | "computedAlloc"
+  | "computedEval"
+  | "forRender"
+  | "forTotalRenderTime"
+  | "forSlotBuildTime"
+  | "forSwapEffect"
+  | "forArrayCopy"
+  | "signalSubscribe"
+  | "proxyGetTime"
+  | "wrapTime"
+  | "setPropertyTime"
+  | "signalBumpTime"
+  | "spliceTime";
 
 export interface Profile {
   /** Signal reads that created a subscription (inside a tracked effect) */
@@ -27,47 +41,69 @@ export interface Profile {
   signalWrites: number;
   /** Effect fires (each = one component re-render via tracked()) */
   effectFires: number;
+  /** Accumulated time (ms) per named timing bucket */
+  timings: Record<TimingBucket, number>;
 }
 
+let _enabled = false;
 let _signalReads = 0;
 let _signalSkips = 0;
 let _signalWrites = 0;
 let _effectFires = 0;
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function -- intentional no-op for zero-cost disabled state
-function noop(): void {}
+const _timings: Record<TimingBucket, number> = {
+  trackedSetup: 0,
+  trackedHookTime: 0,
+  trackedEffectTime: 0,
+  trackedRenderTime: 0,
+  effectCleanupTime: 0,
+  computedSetup: 0,
+  computedAlloc: 0,
+  computedEval: 0,
+  forRender: 0,
+  forTotalRenderTime: 0,
+  forSlotBuildTime: 0,
+  forSwapEffect: 0,
+  forArrayCopy: 0,
+  signalSubscribe: 0,
+  proxyGetTime: 0,
+  wrapTime: 0,
+  setPropertyTime: 0,
+  signalBumpTime: 0,
+  spliceTime: 0,
+};
 
-function countSignalRead(): void {
-  _signalReads++;
-}
-function countSignalSkip(): void {
-  _signalSkips++;
-}
-function countSignalWrite(): void {
-  _signalWrites++;
-}
-function countEffectFire(): void {
-  _effectFires++;
-}
+const _timingStarts: Record<string, number> = {};
 
-// Exported as mutable bindings — swapped between no-ops and counters
-export let profileSignalRead: () => void = noop;
-export let profileSignalSkip: () => void = noop;
-export let profileSignalWrite: () => void = noop;
-export let profileEffectFire: () => void = noop;
+export function profileSignalRead(): void {
+  if (_enabled) _signalReads++;
+}
+export function profileSignalSkip(): void {
+  if (_enabled) _signalSkips++;
+}
+export function profileSignalWrite(): void {
+  if (_enabled) _signalWrites++;
+}
+export function profileEffectFire(): void {
+  if (_enabled) _effectFires++;
+}
+export function profileTimeStart(bucket: TimingBucket): void {
+  if (_enabled) _timingStarts[bucket] = performance.now();
+}
+export function profileTimeEnd(bucket: TimingBucket): void {
+  if (!_enabled) return;
+  const start = _timingStarts[bucket];
+  if (start !== undefined) {
+    _timings[bucket] += performance.now() - start;
+  }
+}
 
 export function enableProfiling(): void {
-  profileSignalRead = countSignalRead;
-  profileSignalSkip = countSignalSkip;
-  profileSignalWrite = countSignalWrite;
-  profileEffectFire = countEffectFire;
+  _enabled = true;
 }
 
 export function disableProfiling(): void {
-  profileSignalRead = noop;
-  profileSignalSkip = noop;
-  profileSignalWrite = noop;
-  profileEffectFire = noop;
+  _enabled = false;
 }
 
 export function resetProfiler(): void {
@@ -75,6 +111,9 @@ export function resetProfiler(): void {
   _signalSkips = 0;
   _signalWrites = 0;
   _effectFires = 0;
+  for (const key of Object.keys(_timings) as TimingBucket[]) {
+    _timings[key] = 0;
+  }
 }
 
 export function getProfile(): Profile {
@@ -83,6 +122,7 @@ export function getProfile(): Profile {
     signalSkips: _signalSkips,
     signalWrites: _signalWrites,
     effectFires: _effectFires,
+    timings: { ..._timings },
   };
 }
 

--- a/packages/core/src/profiler.ts
+++ b/packages/core/src/profiler.ts
@@ -71,7 +71,7 @@ const _timings: Record<TimingBucket, number> = {
   arrayMutatorTime: 0,
 };
 
-const _timingStarts: Record<string, number> = {};
+const _timingStarts: Partial<Record<TimingBucket, number>> = {};
 
 export function profileSignalRead(): void {
   if (_enabled) _signalReads++;
@@ -117,7 +117,7 @@ export function resetProfiler(): void {
   for (const key of Object.keys(_timings) as TimingBucket[]) {
     _timings[key] = 0;
   }
-  for (const key of Object.keys(_timingStarts)) {
+  for (const key of Object.keys(_timingStarts) as TimingBucket[]) {
     delete _timingStarts[key];
   }
 }

--- a/packages/core/src/profiler.ts
+++ b/packages/core/src/profiler.ts
@@ -25,6 +25,7 @@ export type TimingBucket =
   | "forSwapEffect"
   | "forArrayCopy"
   | "signalSubscribe"
+  | "proxyGetTime"
   | "wrapTime"
   | "setPropertyTime"
   | "signalBumpTime"
@@ -63,6 +64,7 @@ const _timings: Record<TimingBucket, number> = {
   forSwapEffect: 0,
   forArrayCopy: 0,
   signalSubscribe: 0,
+  proxyGetTime: 0,
   wrapTime: 0,
   setPropertyTime: 0,
   signalBumpTime: 0,

--- a/packages/core/src/profiler.ts
+++ b/packages/core/src/profiler.ts
@@ -1,9 +1,9 @@
 /**
  * Lightweight profiler for diagnosing signal subscription and render behavior.
  *
- * Zero cost when disabled — all profiling functions check a single boolean
- * that V8 branch-predicts as false. The functions themselves are constant
- * (not swapped via mutable let bindings) so V8 can inline them.
+ * When disabled, profiling adds only a single, predictable boolean check per call,
+ * which V8 can efficiently branch-predict as false. The functions themselves are
+ * constant (not swapped via mutable let bindings) so V8 can inline them.
  *
  * Enable with `enableProfiling()`, read with `getProfile()`, reset with `resetProfiler()`.
  */
@@ -30,7 +30,7 @@ export type TimingBucket =
   | "wrapTime"
   | "setPropertyTime"
   | "signalBumpTime"
-  | "spliceTime";
+  | "arrayMutatorTime";
 
 export interface Profile {
   /** Signal reads that created a subscription (inside a tracked effect) */
@@ -70,7 +70,7 @@ const _timings: Record<TimingBucket, number> = {
   wrapTime: 0,
   setPropertyTime: 0,
   signalBumpTime: 0,
-  spliceTime: 0,
+  arrayMutatorTime: 0,
 };
 
 const _timingStarts: Record<string, number> = {};
@@ -95,6 +95,7 @@ export function profileTimeEnd(bucket: TimingBucket): void {
   const start = _timingStarts[bucket];
   if (start !== undefined) {
     _timings[bucket] += performance.now() - start;
+    delete _timingStarts[bucket];
   }
 }
 
@@ -113,6 +114,9 @@ export function resetProfiler(): void {
   _effectFires = 0;
   for (const key of Object.keys(_timings) as TimingBucket[]) {
     _timings[key] = 0;
+  }
+  for (const key of Object.keys(_timingStarts)) {
+    delete _timingStarts[key];
   }
 }
 

--- a/packages/core/src/read.ts
+++ b/packages/core/src/read.ts
@@ -55,79 +55,88 @@ function trackArrayVersion(value: unknown): void {
   }
 }
 
+function proxyGet(target: any, prop: PropertyKey, receiver: any): any {
+  if (typeof prop === "string") {
+    const existingNodes = (target as any)[$NODE];
+    if (existingNodes) {
+      const tracked = existingNodes[prop];
+      if (tracked) {
+        if (!getCurrentSub()) {
+          profileSignalSkip();
+          return wrap((target as any)[prop]);
+        }
+        profileSignalRead();
+        const value = tracked();
+        if (isWrappable(value)) {
+          const proxy = createReactiveProxy(value);
+          trackArrayVersion(value);
+          return proxy;
+        }
+        return value;
+      }
+    }
+  }
+
+  if (prop === $RAW) {
+    return target;
+  }
+  if (prop === $PROXY) {
+    return receiver;
+  }
+  if (prop === $TRACK) {
+    trackSelf(target);
+    return receiver;
+  }
+  if (prop === $VERSION) {
+    const nodes = (target as any)[$NODE];
+    return nodes?.[$VERSION] ? nodes[$VERSION]() : 0;
+  }
+
+  const value = (target as any)[prop];
+
+  if (typeof value === "function") {
+    if (Array.isArray(target)) {
+      if (getCurrentSub()) {
+        trackSelf(target);
+      }
+      if (typeof prop === "string" && ARRAY_MUTATORS.has(prop)) {
+        return (...args: any[]) => {
+          profileTimeStart("arrayMutatorTime");
+          startBatch();
+          try {
+            return value.apply(receiver, args);
+          } finally {
+            endBatch();
+            profileTimeEnd("arrayMutatorTime");
+          }
+        };
+      }
+    }
+    return value;
+  }
+
+  if (!getCurrentSub()) {
+    profileSignalSkip();
+    return wrap(value);
+  }
+
+  profileSignalRead();
+  const nodes = getNodes(target);
+  const node = getNode(nodes, prop, value);
+  return wrap(node());
+}
+
 const readHandler: Pick<
   ProxyHandler<object>,
   "get" | "ownKeys" | "has" | "getOwnPropertyDescriptor"
 > = {
   get(target, prop, receiver) {
-    if (typeof prop === "string") {
-      const existingNodes = (target as any)[$NODE];
-      if (existingNodes) {
-        const tracked = existingNodes[prop];
-        if (tracked) {
-          if (!getCurrentSub()) {
-            profileSignalSkip();
-            return wrap((target as any)[prop]);
-          }
-          profileSignalRead();
-          const value = tracked();
-          if (isWrappable(value)) {
-            const proxy = createReactiveProxy(value);
-            trackArrayVersion(value);
-            return proxy;
-          }
-          return value;
-        }
-      }
+    profileTimeStart("proxyGetTime");
+    try {
+      return proxyGet(target, prop, receiver);
+    } finally {
+      profileTimeEnd("proxyGetTime");
     }
-
-    if (prop === $RAW) {
-      return target;
-    }
-    if (prop === $PROXY) {
-      return receiver;
-    }
-    if (prop === $TRACK) {
-      trackSelf(target);
-      return receiver;
-    }
-    if (prop === $VERSION) {
-      const nodes = (target as any)[$NODE];
-      return nodes?.[$VERSION] ? nodes[$VERSION]() : 0;
-    }
-
-    const value = (target as any)[prop];
-
-    if (typeof value === "function") {
-      if (Array.isArray(target)) {
-        if (getCurrentSub()) {
-          trackSelf(target);
-        }
-        if (typeof prop === "string" && ARRAY_MUTATORS.has(prop)) {
-          return (...args: any[]) => {
-            profileTimeStart("arrayMutatorTime");
-            startBatch();
-            try {
-              return value.apply(receiver, args);
-            } finally {
-              endBatch();
-              profileTimeEnd("arrayMutatorTime");
-            }
-          };
-        }
-      }
-      return value;
-    }
-
-    if (!getCurrentSub()) {
-      profileSignalSkip();
-      return wrap(value);
-    }
-
-    profileSignalRead();
-    const nodes = getNodes(target);
-    const node = getNode(nodes, prop, value);
-    return wrap(node());
   },
 
   ownKeys(target) {

--- a/packages/core/src/read.ts
+++ b/packages/core/src/read.ts
@@ -55,88 +55,80 @@ function trackArrayVersion(value: unknown): void {
   }
 }
 
-function proxyGet(target: any, prop: PropertyKey, receiver: any): any {
-  if (typeof prop === "string") {
-    const existingNodes = (target as any)[$NODE];
-    if (existingNodes) {
-      const tracked = existingNodes[prop];
-      if (tracked) {
-        if (!getCurrentSub()) {
-          profileSignalSkip();
-          return wrap((target as any)[prop]);
-        }
-        profileSignalRead();
-        const value = tracked();
-        if (isWrappable(value)) {
-          const proxy = createReactiveProxy(value);
-          trackArrayVersion(value);
-          return proxy;
-        }
-        return value;
-      }
-    }
-  }
-
-  if (prop === $RAW) {
-    return target;
-  }
-  if (prop === $PROXY) {
-    return receiver;
-  }
-  if (prop === $TRACK) {
-    trackSelf(target);
-    return receiver;
-  }
-  if (prop === $VERSION) {
-    const nodes = (target as any)[$NODE];
-    return nodes?.[$VERSION] ? nodes[$VERSION]() : 0;
-  }
-
-  const value = (target as any)[prop];
-
-  if (typeof value === "function") {
-    if (Array.isArray(target)) {
-      if (getCurrentSub()) {
-        trackSelf(target);
-      }
-      if (typeof prop === "string" && ARRAY_MUTATORS.has(prop)) {
-        return (...args: any[]) => {
-          profileTimeStart("arrayMutatorTime");
-          startBatch();
-          try {
-            return value.apply(receiver, args);
-          } finally {
-            endBatch();
-            profileTimeEnd("arrayMutatorTime");
-          }
-        };
-      }
-    }
-    return value;
-  }
-
-  if (!getCurrentSub()) {
-    profileSignalSkip();
-    return wrap(value);
-  }
-
-  profileSignalRead();
-  const nodes = getNodes(target);
-  const node = getNode(nodes, prop, value);
-  return wrap(node());
-}
-
 const readHandler: Pick<
   ProxyHandler<object>,
   "get" | "ownKeys" | "has" | "getOwnPropertyDescriptor"
 > = {
   get(target, prop, receiver) {
-    profileTimeStart("proxyGetTime");
-    try {
-      return proxyGet(target, prop, receiver);
-    } finally {
-      profileTimeEnd("proxyGetTime");
+    // Hot path: string property with existing signal node
+    if (typeof prop === "string") {
+      const existingNodes = (target as any)[$NODE];
+      if (existingNodes) {
+        const tracked = existingNodes[prop];
+        if (tracked) {
+          if (!getCurrentSub()) {
+            profileSignalSkip();
+            return wrap((target as any)[prop]);
+          }
+          profileSignalRead();
+          const value = tracked();
+          if (isWrappable(value)) {
+            const proxy = createReactiveProxy(value);
+            trackArrayVersion(value);
+            return proxy;
+          }
+          return value;
+        }
+      }
     }
+
+    if (prop === $RAW) {
+      return target;
+    }
+    if (prop === $PROXY) {
+      return receiver;
+    }
+    if (prop === $TRACK) {
+      trackSelf(target);
+      return receiver;
+    }
+    if (prop === $VERSION) {
+      const nodes = (target as any)[$NODE];
+      return nodes?.[$VERSION] ? nodes[$VERSION]() : 0;
+    }
+
+    const value = (target as any)[prop];
+
+    if (typeof value === "function") {
+      if (Array.isArray(target)) {
+        if (getCurrentSub()) {
+          trackSelf(target);
+        }
+        if (typeof prop === "string" && ARRAY_MUTATORS.has(prop)) {
+          return (...args: any[]) => {
+            profileTimeStart("arrayMutatorTime");
+            startBatch();
+            try {
+              return value.apply(receiver, args);
+            } finally {
+              endBatch();
+              profileTimeEnd("arrayMutatorTime");
+            }
+          };
+        }
+      }
+      return value;
+    }
+
+    if (!getCurrentSub()) {
+      profileSignalSkip();
+      return wrap(value);
+    }
+
+    profileSignalRead();
+    const nodes = getNodes(target);
+    const node = getNode(nodes, prop, value);
+    return wrap(node());
   },
 
   ownKeys(target) {

--- a/packages/core/src/read.ts
+++ b/packages/core/src/read.ts
@@ -105,13 +105,13 @@ const readHandler: Pick<
         }
         if (typeof prop === "string" && ARRAY_MUTATORS.has(prop)) {
           return (...args: any[]) => {
-            profileTimeStart("spliceTime");
+            profileTimeStart("arrayMutatorTime");
             startBatch();
             try {
               return value.apply(receiver, args);
             } finally {
               endBatch();
-              profileTimeEnd("spliceTime");
+              profileTimeEnd("arrayMutatorTime");
             }
           };
         }

--- a/packages/core/src/read.ts
+++ b/packages/core/src/read.ts
@@ -1,7 +1,7 @@
 import { getCurrentSub, startBatch, endBatch } from "alien-signals";
 
 import { $NODE, $OWN_KEYS, $PROXY, $RAW, $TRACK, $VERSION, getNode, getNodes } from "./core";
-import { profileSignalRead, profileSignalSkip } from "./profiler";
+import { profileSignalRead, profileSignalSkip, profileTimeStart, profileTimeEnd } from "./profiler";
 import { writeHandler } from "./write";
 
 const ARRAY_MUTATORS = new Set([
@@ -24,7 +24,14 @@ const isWrappable = (value: unknown): value is object =>
   (value.constructor === Object || value.constructor === Array);
 
 function wrap<T>(value: T): T {
-  return isWrappable(value) ? createReactiveProxy(value) : value;
+  // Fast-path: primitives (number, string, boolean, null, undefined) skip isWrappable call
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+  profileTimeStart("wrapTime");
+  const result = isWrappable(value) ? createReactiveProxy(value) : value;
+  profileTimeEnd("wrapTime");
+  return result;
 }
 
 function trackSelf(target: object): void {
@@ -98,11 +105,13 @@ const readHandler: Pick<
         }
         if (typeof prop === "string" && ARRAY_MUTATORS.has(prop)) {
           return (...args: any[]) => {
+            profileTimeStart("spliceTime");
             startBatch();
             try {
               return value.apply(receiver, args);
             } finally {
               endBatch();
+              profileTimeEnd("spliceTime");
             }
           };
         }

--- a/packages/core/src/write.ts
+++ b/packages/core/src/write.ts
@@ -1,8 +1,8 @@
-import { $NODE, $OWN_KEYS, $VERSION, unwrap, getNodes } from "./core";
-import { profileSignalWrite } from "./profiler";
+import { $OWN_KEYS, $VERSION, unwrap, getNodes, getNodesIfExist } from "./core";
+import { profileSignalWrite, profileTimeStart, profileTimeEnd } from "./profiler";
 
 export function bumpVersion(target: object): void {
-  let nodes = (target as any)[$NODE];
+  let nodes = getNodesIfExist(target);
   if (!nodes) {
     // Lazily create nodes + version signal on first mutation
     nodes = getNodes(target);
@@ -14,7 +14,7 @@ export function bumpVersion(target: object): void {
 }
 
 export function bumpOwnKeysSignal(target: object, nodes?: Record<PropertyKey, any>): void {
-  const resolvedNodes = nodes ?? (target as any)[$NODE];
+  const resolvedNodes = nodes ?? getNodesIfExist(target);
   if (!resolvedNodes) {
     return;
   }
@@ -27,7 +27,7 @@ export function bumpOwnKeysSignal(target: object, nodes?: Record<PropertyKey, an
 }
 
 function bumpSignals(target: any, key: PropertyKey, prevLen: number): void {
-  const nodes = (target as any)[$NODE];
+  const nodes = getNodesIfExist(target);
   if (!nodes) {
     return;
   }
@@ -41,6 +41,7 @@ function bumpSignals(target: any, key: PropertyKey, prevLen: number): void {
 }
 
 export function setProperty(target: any, key: PropertyKey, value: any): void {
+  profileTimeStart("setPropertyTime");
   const hadKey = Object.hasOwn(target, key);
   const prevLen = Array.isArray(target) ? target.length : -1;
   const oldValue = target[key];
@@ -59,19 +60,22 @@ export function setProperty(target: any, key: PropertyKey, value: any): void {
     }
   }
 
-  const nodes = (target as any)[$NODE];
+  const nodes = getNodesIfExist(target);
   if (nodes) {
     const node = nodes[key];
     if (node && didChange) {
       profileSignalWrite();
+      profileTimeStart("signalBumpTime");
       node(value);
+      profileTimeEnd("signalBumpTime");
     }
   }
   bumpSignals(target, key, prevLen);
 
   if (!hadKey) {
-    bumpOwnKeysSignal(target, (target as any)[$NODE]);
+    bumpOwnKeysSignal(target, getNodesIfExist(target));
   }
+  profileTimeEnd("setPropertyTime");
 }
 
 export function deleteProperty(target: any, key: PropertyKey): void {
@@ -83,7 +87,7 @@ export function deleteProperty(target: any, key: PropertyKey): void {
   if (hadKey) {
     bumpVersion(target);
 
-    const nodes = (target as any)[$NODE];
+    const nodes = getNodesIfExist(target);
     if (nodes) {
       const node = nodes[key];
       if (node) {
@@ -92,7 +96,7 @@ export function deleteProperty(target: any, key: PropertyKey): void {
       }
     }
     bumpSignals(target, key, prevLen);
-    bumpOwnKeysSignal(target, (target as any)[$NODE]);
+    bumpOwnKeysSignal(target, getNodesIfExist(target));
   }
 }
 

--- a/packages/doc-tests/tests/readme-validation.test.ts
+++ b/packages/doc-tests/tests/readme-validation.test.ts
@@ -1,17 +1,28 @@
 /**
- * README Documentation Validation Tests
+ * Documentation Validation Tests
  *
  * Tests that ensure:
- * - All code blocks in README.md have DOC_TEST identifiers
+ * - All code blocks in README.md and docs/*.md have DOC_TEST identifiers
  * - All DOC_TEST identifiers have corresponding tests in the test suite
  */
 
-import { readFileSync, readdirSync } from "fs";
+import { readFileSync, readdirSync, existsSync } from "fs";
 import { join } from "path";
 import { describe, it, expect } from "vitest";
 
 describe("README Documentation Validation", () => {
-  const readmeContent = readFileSync(join(__dirname, "../../../README.md"), "utf-8");
+  const rootDir = join(__dirname, "../../..");
+  // Collect all documentation markdown: README.md + docs/*.md
+  const docFiles = [join(rootDir, "README.md")];
+  const docsDir = join(rootDir, "docs");
+  if (existsSync(docsDir)) {
+    for (const file of readdirSync(docsDir)) {
+      if (file.endsWith(".md")) {
+        docFiles.push(join(docsDir, file));
+      }
+    }
+  }
+  const readmeContent = docFiles.map((f) => readFileSync(f, "utf-8")).join("\n");
 
   const testsDir = __dirname;
   const testFiles = readdirSync(testsDir)

--- a/packages/js-krauset/package.json
+++ b/packages/js-krauset/package.json
@@ -16,6 +16,7 @@
     "react-dom": "19.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-strip": "^3.0.4",
     "@types/node": "^22.18.3",
     "@types/ramda": "^0.31.1",
     "@types/react": "^19.1.13",

--- a/packages/js-krauset/vite.config.ts
+++ b/packages/js-krauset/vite.config.ts
@@ -1,3 +1,4 @@
+import strip from "@rollup/plugin-strip";
 import react from "@vitejs/plugin-react";
 /// <reference types="vitest" />
 import { resolve } from "path";
@@ -11,6 +12,17 @@ export default defineConfig({
       insertTypesEntry: true,
     }),
     react(),
+    // Strip profiler calls from production builds — zero runtime cost.
+    strip({
+      functions: [
+        "profileTimeStart",
+        "profileTimeEnd",
+        "profileSignalRead",
+        "profileSignalSkip",
+        "profileSignalWrite",
+        "profileEffectFire",
+      ],
+    }),
   ],
 
   // This is the key change:

--- a/packages/react/src/tracked.ts
+++ b/packages/react/src/tracked.ts
@@ -121,12 +121,10 @@ export function tracked<P extends object>(Component: FC<P>) {
     profileTimeStart("trackedRenderTime");
     const prev = getCurrentSub();
     setCurrentSub(ref.current.effectNode);
-    try {
-      return Component(props); // eslint-disable-line new-cap -- React function component call
-    } finally {
-      setCurrentSub(prev);
-      profileTimeEnd("trackedRenderTime");
-    }
+    const result = Component(props); // eslint-disable-line new-cap -- React function component call
+    setCurrentSub(prev);
+    profileTimeEnd("trackedRenderTime");
+    return result;
   };
 
   return memo(Tracked);

--- a/packages/react/src/tracked.ts
+++ b/packages/react/src/tracked.ts
@@ -104,7 +104,7 @@ export function tracked<P extends object>(Component: FC<P>) {
     }
 
     profileTimeStart("trackedHookTime");
-    useSyncExternalStore(ref.current.subscribe, ref.current.getSnapshot);
+    useSyncExternalStore(ref.current.subscribe, ref.current.getSnapshot, ref.current.getSnapshot);
 
     useEffect(
       () => () => {

--- a/packages/react/src/tracked.ts
+++ b/packages/react/src/tracked.ts
@@ -4,6 +4,7 @@ import {
   setCurrentSub,
   profileTimeStart,
   profileTimeEnd,
+  type ReactiveNode,
 } from "@supergrain/core";
 import { type FC, memo, useEffect, useRef, useSyncExternalStore } from "react";
 
@@ -51,7 +52,7 @@ import { type FC, memo, useEffect, useRef, useSyncExternalStore } from "react";
 /** Internal state for a tracked component instance. */
 interface TrackedState {
   cleanup: () => void;
-  effectNode: any;
+  effectNode: ReactiveNode | undefined;
   version: number;
   listener: (() => void) | null;
   subscribe: (cb: () => void) => () => void;
@@ -71,7 +72,7 @@ export function tracked<P extends object>(Component: FC<P>) {
       // All mutable state lives on the state object to minimize closure contexts.
       // subscribe/getSnapshot/unsubscribe close over `state` only (one V8 Context).
       const state: TrackedState = {
-        effectNode: null,
+        effectNode: undefined,
         version: 0,
         listener: null,
         cleanup: null!,

--- a/packages/react/src/tracked.ts
+++ b/packages/react/src/tracked.ts
@@ -1,5 +1,10 @@
-import { profileTimeStart, profileTimeEnd, profileEffectFire } from "@supergrain/core";
-import { effect as alienEffect, getCurrentSub, setCurrentSub } from "alien-signals";
+import {
+  effect,
+  getCurrentSub,
+  setCurrentSub,
+  profileTimeStart,
+  profileTimeEnd,
+} from "@supergrain/core";
 import { type FC, memo, useEffect, useRef, useSyncExternalStore } from "react";
 
 /**
@@ -83,15 +88,12 @@ export function tracked<P extends object>(Component: FC<P>) {
       };
 
       let firstRun = true;
-      // Use alienEffect directly to avoid profiledEffect's double-callback overhead.
-      // profileEffectFire() is called manually on re-runs.
-      state.cleanup = alienEffect(() => {
+      state.cleanup = effect(() => {
         if (firstRun) {
           state.effectNode = getCurrentSub();
           firstRun = false;
           return;
         }
-        profileEffectFire();
         state.version++;
         state.listener?.();
       });
@@ -118,10 +120,12 @@ export function tracked<P extends object>(Component: FC<P>) {
     profileTimeStart("trackedRenderTime");
     const prev = getCurrentSub();
     setCurrentSub(ref.current.effectNode);
-    const result = Component(props); // eslint-disable-line new-cap -- React function component call
-    setCurrentSub(prev);
-    profileTimeEnd("trackedRenderTime");
-    return result;
+    try {
+      return Component(props); // eslint-disable-line new-cap -- React function component call
+    } finally {
+      setCurrentSub(prev);
+      profileTimeEnd("trackedRenderTime");
+    }
   };
 
   return memo(Tracked);

--- a/packages/react/src/tracked.ts
+++ b/packages/react/src/tracked.ts
@@ -1,5 +1,6 @@
-import { effect, getCurrentSub, setCurrentSub } from "@supergrain/core";
-import { type FC, memo, useReducer, useRef, useEffect } from "react";
+import { profileTimeStart, profileTimeEnd, profileEffectFire } from "@supergrain/core";
+import { effect as alienEffect, getCurrentSub, setCurrentSub } from "alien-signals";
+import { type FC, memo, useEffect, useRef, useSyncExternalStore } from "react";
 
 /**
  * Wraps a React component with per-component signal scoping.
@@ -41,37 +42,85 @@ import { type FC, memo, useReducer, useRef, useEffect } from "react";
  * })
  * ```
  */
+
+/** Internal state for a tracked component instance. */
+interface TrackedState {
+  cleanup: () => void;
+  effectNode: any;
+  version: number;
+  listener: (() => void) | null;
+  subscribe: (cb: () => void) => () => void;
+  getSnapshot: () => number;
+  unsubscribe: () => void;
+}
+
 export function tracked<P extends object>(Component: FC<P>) {
   const Tracked: FC<P> = (props: P) => {
-    const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
-    const ref = useRef<{ cleanup: () => void; effectNode: any } | null>(null);
+    profileTimeStart("trackedHookTime");
+    const ref = useRef<TrackedState | null>(null);
+    profileTimeEnd("trackedHookTime");
 
     if (!ref.current) {
-      let effectNode: any = null;
+      profileTimeStart("trackedSetup");
+      profileTimeStart("trackedEffectTime");
+      // All mutable state lives on the state object to minimize closure contexts.
+      // subscribe/getSnapshot/unsubscribe close over `state` only (one V8 Context).
+      const state: TrackedState = {
+        effectNode: null,
+        version: 0,
+        listener: null,
+        cleanup: null!,
+        unsubscribe() {
+          state.listener = null;
+        },
+        subscribe(cb: () => void) {
+          state.listener = cb;
+          return state.unsubscribe;
+        },
+        getSnapshot() {
+          return state.version;
+        },
+      };
+
       let firstRun = true;
-      const cleanup = effect(() => {
+      // Use alienEffect directly to avoid profiledEffect's double-callback overhead.
+      // profileEffectFire() is called manually on re-runs.
+      state.cleanup = alienEffect(() => {
         if (firstRun) {
-          effectNode = getCurrentSub();
+          state.effectNode = getCurrentSub();
           firstRun = false;
           return;
         }
-        forceUpdate();
+        profileEffectFire();
+        state.version++;
+        state.listener?.();
       });
-      ref.current = { cleanup, effectNode };
+
+      ref.current = state;
+      profileTimeEnd("trackedEffectTime");
+      profileTimeEnd("trackedSetup");
     }
+
+    profileTimeStart("trackedHookTime");
+    useSyncExternalStore(ref.current.subscribe, ref.current.getSnapshot);
 
     useEffect(
       () => () => {
+        profileTimeStart("effectCleanupTime");
         ref.current?.cleanup?.();
         ref.current = null;
+        profileTimeEnd("effectCleanupTime");
       },
       [],
     );
+    profileTimeEnd("trackedHookTime");
 
+    profileTimeStart("trackedRenderTime");
     const prev = getCurrentSub();
     setCurrentSub(ref.current.effectNode);
     const result = Component(props); // eslint-disable-line new-cap -- React function component call
     setCurrentSub(prev);
+    profileTimeEnd("trackedRenderTime");
     return result;
   };
 

--- a/packages/react/src/use-computed.ts
+++ b/packages/react/src/use-computed.ts
@@ -1,4 +1,4 @@
-import { computed } from "@supergrain/core";
+import { computed, profileTimeStart, profileTimeEnd } from "@supergrain/core";
 import { useMemo } from "react";
 
 /**
@@ -28,6 +28,16 @@ import { useMemo } from "react";
  * ```
  */
 export function useComputed<T>(factory: () => T, deps: readonly unknown[] = []): T {
-  const c = useMemo(() => computed(factory), deps); // eslint-disable-line react-hooks/exhaustive-deps
-  return c();
+  const c = useMemo(() => {
+    profileTimeStart("computedSetup");
+    profileTimeStart("computedAlloc");
+    const s = computed(factory);
+    profileTimeEnd("computedAlloc");
+    profileTimeEnd("computedSetup");
+    return s;
+  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+  profileTimeStart("computedEval");
+  const value = c();
+  profileTimeEnd("computedEval");
+  return value;
 }

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -1,10 +1,17 @@
-import { effect as alienEffect, getCurrentSub, setCurrentSub, unwrap } from "@supergrain/core";
+import {
+  effect as alienEffect,
+  getCurrentSub,
+  setCurrentSub,
+  unwrap,
+  profileTimeStart,
+  profileTimeEnd,
+  getNodesIfExist,
+} from "@supergrain/core";
 import React, { useEffect, useLayoutEffect, useRef } from "react";
 
 import { tracked } from "./tracked";
 
 const $TRACK = Symbol.for("supergrain:track");
-const $NODE = Symbol.for("supergrain:node");
 
 interface ForProps<T> {
   each: T[];
@@ -34,55 +41,26 @@ const ForItem = tracked(
 );
 
 /**
- * Cached ForItem — caches its item in a ref for O(1) swap support.
- *
- * Only re-reads from the array when the index prop changes (structural
- * change). On property-change re-renders, uses the cached item — so it
- * always renders the correct content even if the DOM was moved by the
- * alien swap effect.
- */
-const CachedForItem = tracked(
-  ({
-    each,
-    index,
-    children,
-  }: {
-    each: unknown[];
-    index: number;
-    children: (item: unknown, index: number) => React.ReactNode;
-  }) => {
-    const prevIndexRef = useRef(index);
-    const itemRef = useRef<unknown>(null);
-
-    if (itemRef.current === null || prevIndexRef.current !== index) {
-      const prevSub = getCurrentSub();
-      setCurrentSub(undefined as any); // eslint-disable-line unicorn/no-useless-undefined -- intentionally clearing subscriber
-      itemRef.current = each[index];
-      setCurrentSub(prevSub);
-      prevIndexRef.current = index;
-    }
-
-    const child = children(itemRef.current, index);
-    return child as React.ReactElement;
-  },
-);
-
-/**
  * List rendering component with fine-grained per-element reactivity.
  *
  * When a `parent` ref is provided, For uses O(1) direct DOM moves on swap:
- * an alien-signals effect detects element swaps and moves DOM nodes.
- * CachedForItem ensures label changes still render correctly after a move.
+ * an alien-signals effect detects element swaps and moves DOM nodes directly.
+ * Children are called once with the reactive proxy item and keep their
+ * original item props after swaps (since For doesn't re-render on swap).
  *
  * Without `parent`, For falls back to O(n) React keyed reconciliation.
  *
  * Both modes:
  * - Add/Remove: For re-renders to adjust slot count. React handles it.
- * - Property update: Only the affected ForItem re-renders (via tracked).
+ * - Property update: Only the affected child re-renders (via tracked).
+ *
+ * **Important**: When using the `parent` prop, children MUST be `tracked()`
+ * components (e.g., `<Row />`). For calls children directly without a wrapper,
+ * so inline children won't have reactive subscriptions for property changes.
  *
  * @example
  * ```tsx
- * // Fast path — O(1) swap
+ * // Fast path — O(1) swap (children must be tracked)
  * const tbodyRef = useRef<HTMLTableSectionElement>(null)
  * <tbody ref={tbodyRef}>
  *   <For each={store.data} parent={tbodyRef}>
@@ -90,7 +68,7 @@ const CachedForItem = tracked(
  *   </For>
  * </tbody>
  *
- * // Standard path — no ref needed
+ * // Standard path — no ref needed, inline children OK
  * <For each={store.data}>
  *   {(item) => <Row key={item.id} item={item} />}
  * </For>
@@ -98,6 +76,7 @@ const CachedForItem = tracked(
  */
 // tracked() erases the generic <T>, so we cast through unknown to restore it.
 export const For = tracked((props: ForProps<unknown>) => {
+  profileTimeStart("forRender");
   const { each, children, fallback, parent } = props;
   const prevRawRef = useRef<unknown[]>([]);
   const swapCleanupRef = useRef<(() => void) | null>(null);
@@ -120,10 +99,14 @@ export const For = tracked((props: ForProps<unknown>) => {
     }
 
     swapCleanupRef.current?.();
+    profileTimeStart("forArrayCopy");
     prevRawRef.current = [...raw];
+    profileTimeEnd("forArrayCopy");
 
     const cleanup = alienEffect(() => {
-      const nodes = (raw as any)[$NODE];
+      profileTimeStart("forSwapEffect");
+      profileTimeStart("signalSubscribe");
+      const nodes = getNodesIfExist(raw);
       for (let i = 0; i < raw.length; i++) {
         if (nodes?.[i]) {
           nodes[i]();
@@ -131,11 +114,15 @@ export const For = tracked((props: ForProps<unknown>) => {
           void each[i];
         }
       }
+      profileTimeEnd("signalSubscribe");
 
       const prev = prevRawRef.current;
       const container = parent.current;
       if (!container || prev.length !== raw.length) {
+        profileTimeStart("forArrayCopy");
         prevRawRef.current = [...raw];
+        profileTimeEnd("forArrayCopy");
+        profileTimeEnd("forSwapEffect");
         return;
       }
 
@@ -163,9 +150,17 @@ export const For = tracked((props: ForProps<unknown>) => {
             container.append(nodeB);
           }
         }
+        // Update prev from raw (not swapping within prev) to preserve
+        // object identity — raw may contain proxy wrappers while prev
+        // has raw objects, so we must copy from raw for === to work.
+        prev[a] = raw[a];
+        prev[b] = raw[b];
+      } else {
+        profileTimeStart("forArrayCopy");
+        prevRawRef.current = [...raw];
+        profileTimeEnd("forArrayCopy");
       }
-
-      prevRawRef.current = [...raw];
+      profileTimeEnd("forSwapEffect");
     });
 
     swapCleanupRef.current = cleanup;
@@ -180,12 +175,28 @@ export const For = tracked((props: ForProps<unknown>) => {
   );
 
   if (!raw || raw.length === 0) {
+    profileTimeEnd("forRender");
     return fallback ? React.createElement(React.Fragment, null, fallback) : null;
   }
 
-  // Without parent: subscribe to per-index signals for React reconciliation on swap.
-  if (!parent) {
-    const nodes = (raw as any)[$NODE];
+  profileTimeStart("forSlotBuildTime");
+  const slots = Array.from({ length: raw.length });
+
+  if (parent) {
+    // Parent path (O(1) swap): call children directly with untracked array reads.
+    // No wrapper component needed — children (e.g., tracked Row) handle their own
+    // subscriptions. After a swap, For doesn't re-render, so children keep their
+    // original item props. The swap effect moves DOM nodes to match.
+    const prevSub = getCurrentSub();
+    setCurrentSub(undefined as any); // eslint-disable-line unicorn/no-useless-undefined -- untrack array reads to avoid subscribing For to per-index signals
+    for (let i = 0; i < raw.length; i++) {
+      slots[i] = children(each[i], i);
+    }
+    setCurrentSub(prevSub);
+  } else {
+    // Non-parent path: use ForItem wrapper for per-index signal subscription
+    // so React keyed reconciliation handles swaps.
+    const nodes = getNodesIfExist(raw);
     for (let i = 0; i < raw.length; i++) {
       const existingNode = nodes?.[i];
       if (existingNode) {
@@ -194,27 +205,24 @@ export const For = tracked((props: ForProps<unknown>) => {
         void each[i];
       }
     }
-  }
 
-  const ItemComponent = parent ? CachedForItem : ForItem;
+    for (let i = 0; i < raw.length; i++) {
+      const rawItem = raw[i];
+      const key =
+        rawItem && typeof rawItem === "object" && "id" in rawItem
+          ? ((rawItem as Record<string, unknown>).id as React.Key)
+          : i;
 
-  const slots = [];
-  for (let i = 0; i < raw.length; i++) {
-    const rawItem = raw[i];
-    const key =
-      rawItem && typeof rawItem === "object" && "id" in rawItem
-        ? ((rawItem as Record<string, unknown>).id as React.Key)
-        : i;
-
-    slots.push(
-      React.createElement(ItemComponent, {
+      slots[i] = React.createElement(ForItem, {
         key,
         each,
         index: i,
         children,
-      }),
-    );
+      });
+    }
   }
 
-  return React.createElement(React.Fragment, null, ...slots);
+  profileTimeEnd("forSlotBuildTime");
+  profileTimeEnd("forRender");
+  return slots as any;
 }) as unknown as <T>(props: ForProps<T>) => React.JSX.Element | null;

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -10,6 +10,9 @@ import {
 } from "@supergrain/core";
 import React, { useEffect, useLayoutEffect, useRef } from "react";
 
+// useLayoutEffect warns during SSR. Fall back to useEffect on the server.
+const useIsomorphicLayoutEffect = globalThis.document === undefined ? useEffect : useLayoutEffect;
+
 import { tracked } from "./tracked";
 
 interface ForProps<T> {
@@ -86,7 +89,9 @@ export const For = tracked((props: ForProps<unknown>) => {
   const raw = unwrap(each);
 
   // O(1) swap effect — only when parent ref is provided.
-  useLayoutEffect(() => {
+  // No deps array: must re-create the alien-signals effect on every For render
+  // so it captures the latest `raw` array reference after structural changes.
+  useIsomorphicLayoutEffect(() => {
     if (!parent) {
       return;
     }
@@ -187,7 +192,7 @@ export const For = tracked((props: ForProps<unknown>) => {
     // subscriptions. After a swap, For doesn't re-render, so children keep their
     // original item props. The swap effect moves DOM nodes to match.
     const prevSub = getCurrentSub();
-    setCurrentSub(undefined as any); // eslint-disable-line unicorn/no-useless-undefined -- untrack array reads to avoid subscribing For to per-index signals
+    setCurrentSub(undefined); // untrack array reads to avoid subscribing For to per-index signals
     try {
       for (let i = 0; i < raw.length; i++) {
         slots[i] = children(each[i], i);

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -189,10 +189,13 @@ export const For = tracked((props: ForProps<unknown>) => {
     // original item props. The swap effect moves DOM nodes to match.
     const prevSub = getCurrentSub();
     setCurrentSub(undefined as any); // eslint-disable-line unicorn/no-useless-undefined -- untrack array reads to avoid subscribing For to per-index signals
-    for (let i = 0; i < raw.length; i++) {
-      slots[i] = children(each[i], i);
+    try {
+      for (let i = 0; i < raw.length; i++) {
+        slots[i] = children(each[i], i);
+      }
+    } finally {
+      setCurrentSub(prevSub);
     }
-    setCurrentSub(prevSub);
   } else {
     // Non-parent path: use ForItem wrapper for per-index signal subscription
     // so React keyed reconciliation handles swaps.

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -193,13 +193,10 @@ export const For = tracked((props: ForProps<unknown>) => {
     // original item props. The swap effect moves DOM nodes to match.
     const prevSub = getCurrentSub();
     setCurrentSub(undefined); // untrack array reads to avoid subscribing For to per-index signals
-    try {
-      for (let i = 0; i < raw.length; i++) {
-        slots[i] = children(each[i], i);
-      }
-    } finally {
-      setCurrentSub(prevSub);
+    for (let i = 0; i < raw.length; i++) {
+      slots[i] = children(each[i], i);
     }
+    setCurrentSub(prevSub);
   } else {
     // Non-parent path: use ForItem wrapper for per-index signal subscription
     // so React keyed reconciliation handles swaps.

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -6,12 +6,11 @@ import {
   profileTimeStart,
   profileTimeEnd,
   getNodesIfExist,
+  $TRACK,
 } from "@supergrain/core";
 import React, { useEffect, useLayoutEffect, useRef } from "react";
 
 import { tracked } from "./tracked";
-
-const $TRACK = Symbol.for("supergrain:track");
 
 interface ForProps<T> {
   each: T[];

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -180,7 +180,7 @@ export const For = tracked((props: ForProps<unknown>) => {
   }
 
   profileTimeStart("forSlotBuildTime");
-  const slots = Array.from({ length: raw.length });
+  const slots: React.ReactNode[] = Array.from({ length: raw.length });
 
   if (parent) {
     // Parent path (O(1) swap): call children directly with untracked array reads.
@@ -227,5 +227,5 @@ export const For = tracked((props: ForProps<unknown>) => {
 
   profileTimeEnd("forSlotBuildTime");
   profileTimeEnd("forRender");
-  return slots as any;
+  return React.createElement(React.Fragment, null, ...slots);
 }) as unknown as <T>(props: ForProps<T>) => React.JSX.Element | null;

--- a/packages/react/src/use-store.ts
+++ b/packages/react/src/use-store.ts
@@ -1,5 +1,5 @@
 import {
-  effect as alienEffect,
+  effect,
   getCurrentSub,
   setCurrentSub,
   unwrap,
@@ -103,7 +103,7 @@ export const For = tracked((props: ForProps<unknown>) => {
     prevRawRef.current = [...raw];
     profileTimeEnd("forArrayCopy");
 
-    const cleanup = alienEffect(() => {
+    const cleanup = effect(() => {
       profileTimeStart("forSwapEffect");
       profileTimeStart("signalSubscribe");
       const nodes = getNodesIfExist(raw);

--- a/packages/react/tests/for-component-magic.test.tsx
+++ b/packages/react/tests/for-component-magic.test.tsx
@@ -701,6 +701,16 @@ describe("For Component Magic Tests", () => {
       });
     }
 
+    // Parent path requires tracked children for reactive property updates.
+    const StressRow = tracked(({ item }: { item: RowData }) => {
+      return (
+        <tr>
+          <td>{item.id}</td>
+          <td>{item.label}</td>
+        </tr>
+      );
+    });
+
     function getLabels(c: HTMLElement) {
       return Array.from(c.querySelectorAll("tr")).map(
         (tr) => tr.querySelectorAll("td")[1]?.textContent ?? "",
@@ -722,12 +732,7 @@ describe("For Component Magic Tests", () => {
           <table>
             <tbody ref={tbodyRef}>
               <For each={store.data} parent={tbodyRef}>
-                {(item: RowData) => (
-                  <tr key={item.id}>
-                    <td>{item.id}</td>
-                    <td>{item.label}</td>
-                  </tr>
-                )}
+                {(item: RowData) => <StressRow key={item.id} item={item} />}
               </For>
             </tbody>
           </table>
@@ -768,12 +773,7 @@ describe("For Component Magic Tests", () => {
           <table>
             <tbody ref={tbodyRef}>
               <For each={store.data} parent={tbodyRef}>
-                {(item: RowData) => (
-                  <tr key={item.id}>
-                    <td>{item.id}</td>
-                    <td>{item.label}</td>
-                  </tr>
-                )}
+                {(item: RowData) => <StressRow key={item.id} item={item} />}
               </For>
             </tbody>
           </table>
@@ -812,12 +812,7 @@ describe("For Component Magic Tests", () => {
           <table>
             <tbody ref={tbodyRef}>
               <For each={store.data} parent={tbodyRef}>
-                {(item: RowData) => (
-                  <tr key={item.id}>
-                    <td>{item.id}</td>
-                    <td>{item.label}</td>
-                  </tr>
-                )}
+                {(item: RowData) => <StressRow key={item.id} item={item} />}
               </For>
             </tbody>
           </table>
@@ -854,12 +849,7 @@ describe("For Component Magic Tests", () => {
           <table>
             <tbody ref={tbodyRef}>
               <For each={store.data} parent={tbodyRef}>
-                {(item: RowData) => (
-                  <tr key={item.id}>
-                    <td>{item.id}</td>
-                    <td>{item.label}</td>
-                  </tr>
-                )}
+                {(item: RowData) => <StressRow key={item.id} item={item} />}
               </For>
             </tbody>
           </table>
@@ -896,12 +886,7 @@ describe("For Component Magic Tests", () => {
           <table>
             <tbody ref={tbodyRef}>
               <For each={store.data} parent={tbodyRef}>
-                {(item: RowData) => (
-                  <tr key={item.id}>
-                    <td>{item.id}</td>
-                    <td>{item.label}</td>
-                  </tr>
-                )}
+                {(item: RowData) => <StressRow key={item.id} item={item} />}
               </For>
             </tbody>
           </table>
@@ -947,19 +932,22 @@ describe("For Component Magic Tests", () => {
     it("swap then select a swapped item", async () => {
       const store = createTestStore(5);
 
+      const SelectableRow = tracked(({ item }: { item: RowData }) => {
+        return (
+          <tr className={store.selected === item.id ? "danger" : ""}>
+            <td>{item.id}</td>
+            <td>{item.label}</td>
+          </tr>
+        );
+      });
+
       const App = tracked(() => {
         const tbodyRef = React.useRef<HTMLTableSectionElement>(null);
-        const selected = store.selected;
         return (
           <table>
             <tbody ref={tbodyRef}>
               <For each={store.data} parent={tbodyRef}>
-                {(item: RowData) => (
-                  <tr key={item.id} className={selected === item.id ? "danger" : ""}>
-                    <td>{item.id}</td>
-                    <td>{item.label}</td>
-                  </tr>
-                )}
+                {(item: RowData) => <SelectableRow key={item.id} item={item} />}
               </For>
             </tbody>
           </table>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,61 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
     devDependencies:
+      '@rollup/plugin-strip':
+        specifier: ^3.0.4
+        version: 3.0.4(rollup@4.50.1)
+      '@types/node':
+        specifier: ^22.18.3
+        version: 22.18.3
+      '@types/ramda':
+        specifier: ^0.31.1
+        version: 0.31.1
+      '@types/react':
+        specifier: ^19.1.13
+        version: 19.1.13
+      '@types/react-dom':
+        specifier: ^19.1.9
+        version: 19.1.9(@types/react@19.1.13)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@7.1.5(@types/node@22.18.3))
+      '@vitest/browser':
+        specifier: 4.1.0
+        version: 4.1.0(vite@7.1.5(@types/node@22.18.3))(vitest@4.1.0)
+      playwright:
+        specifier: ^1.55.0
+        version: 1.55.0
+      ramda:
+        specifier: ^0.32.0
+        version: 0.32.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      vite:
+        specifier: ^7.1.5
+        version: 7.1.5(@types/node@22.18.3)
+      vite-plugin-dts:
+        specifier: ^4.5.4
+        version: 4.5.4(@types/node@22.18.3)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.3))
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@types/node@22.18.3)(@vitest/browser-playwright@4.1.0)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.18.3))
+
+  packages/js-krauset-main:
+    dependencies:
+      '@supergrain/core':
+        specifier: 2.0.0
+        version: 2.0.0(arktype@2.2.0)
+      '@supergrain/react':
+        specifier: 2.0.0
+        version: 2.0.0(arktype@2.2.0)(react@19.0.0)
+      react:
+        specifier: 19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
+    devDependencies:
       '@types/node':
         specifier: ^22.18.3
         version: 22.18.3
@@ -1134,6 +1189,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rollup/plugin-strip@3.0.4':
+    resolution: {integrity: sha512-LDRV49ZaavxUo2YoKKMQjCxzCxugu1rCPQa0lDYBOWLj6vtzBMr8DcoJjsmg+s450RbKbe3qI9ZLaSO+O1oNbg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -1312,6 +1376,19 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@supergrain/core@2.0.0':
+    resolution: {integrity: sha512-NP/y0kwviXZ7K8ews9nvGWTuddTTzAn8SB89ZxwLTyrb8dAYl5RhyOHCMH0hDUOyNYkLTvYeftyb7eIvYC2RWw==}
+    peerDependencies:
+      arktype: '>=2.0.0'
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+
+  '@supergrain/react@2.0.0':
+    resolution: {integrity: sha512-6lJqRLYBkM+hdT+x4hknNDnOA3hKNLljX3RcozEx6pkY4RCEFtl/oQQYIXBVP32tx2skrStPjW0D4xhGsDfJzA==}
+    peerDependencies:
+      react: ^18.2.0 || ^19.0.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3661,6 +3738,14 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rollup/plugin-strip@3.0.4(rollup@4.50.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.50.1
+
   '@rollup/pluginutils@5.3.0(rollup@4.50.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -3816,6 +3901,19 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@supergrain/core@2.0.0(arktype@2.2.0)':
+    dependencies:
+      alien-signals: 2.0.7
+    optionalDependencies:
+      arktype: 2.2.0
+
+  '@supergrain/react@2.0.0(arktype@2.2.0)(react@19.0.0)':
+    dependencies:
+      '@supergrain/core': 2.0.0(arktype@2.2.0)
+      react: 19.0.0
+    transitivePeerDependencies:
+      - arktype
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

- **`getNodesIfExist()`**: Named helper replacing scattered `(target as any)[$NODE]` lookups. Read-only, no node creation.
- **`wrap()` fast-path**: Skip `isWrappable` call for primitives (number, string, boolean, null, undefined).
- **Profiler upgrade**: Constant functions with boolean check (V8 can inline) instead of mutable function pointer swapping. Adds `TimingBucket` support for detailed performance profiling.
- **`tracked()` rewrite**: `useSyncExternalStore` replaces `useReducer`. All mutable state on a single `TrackedState` ref object, reducing V8 Context allocations per component.
- **Remove `CachedForItem`**: Parent path calls children directly. O(2) swap update instead of O(n) array copy. Parent path contract now requires tracked children (documented, tests updated).

## Benchmark results (5-run medians, total time)

All deltas within noise (spread 7-29%). Branch is performance-neutral.

| Operation | Baseline | Branch | Δ Total |
|---|---|---|---|
| create 1k | 54.3ms | 60.9ms | +12.2%* |
| replace all | 71.3ms | 69.9ms | -2.0%* |
| partial update | 65.2ms | 64.0ms | -1.8%* |
| select row | 14.9ms | 15.6ms | +4.7%* |
| swap rows | 60.6ms | 62.1ms | +2.5%* |
| remove row | 56.9ms | 52.4ms | -7.9%* |
| create 10k | 644.5ms | 641.8ms | -0.4%* |
| append 1k | 71.8ms | 65.5ms | -8.8%* |
| clear rows | 51.1ms | 53.1ms | +3.9%* |

\* = delta smaller than average spread (likely noise)

## Test plan

- [x] All 185 unit tests pass
- [x] All 10 js-krauset correctness tests pass (Playwright)
- [x] Typecheck, lint, formatting all pass
- [x] 5-run benchmark comparison shows no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)