### PR TITLE
Source-first workspace exports to eliminate build-before-test

### DIFF
--- a/packages/doc-tests/tsconfig.json
+++ b/packages/doc-tests/tsconfig.json
@@ -6,13 +6,7 @@
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "@supergrain/kernel": ["../kernel/src"],
-      "@supergrain/kernel/react": ["../kernel/src/react"],
-      "@supergrain/silo": ["../silo/src"]
-    }
+    "skipLibCheck": true
   },
   "include": ["tests/**/*", "vitest.config.ts", "vitest.node.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/doc-tests/vitest.config.ts
+++ b/packages/doc-tests/vitest.config.ts
@@ -1,7 +1,8 @@
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+const conditions = ["@supergrain/source"];
 
 export default defineConfig({
   plugins: [react()],
@@ -21,11 +22,6 @@ export default defineConfig({
     // Exclude readme-validation test from browser mode since it needs Node.js APIs
     exclude: ["**/node_modules/**", "**/readme-validation.test.ts"],
   },
-  resolve: {
-    alias: {
-      "@supergrain/kernel": resolve(__dirname, "../kernel/src"),
-      "@supergrain/kernel/react": resolve(__dirname, "../kernel/src/react"),
-      "@supergrain/silo": resolve(__dirname, "../silo/src"),
-    },
-  },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/doc-tests/vitest.node.config.ts
+++ b/packages/doc-tests/vitest.node.config.ts
@@ -1,5 +1,6 @@
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+const conditions = ["@supergrain/source"];
 
 export default defineConfig({
   test: {
@@ -7,11 +8,6 @@ export default defineConfig({
     globals: true,
     include: ["**/readme-validation.test.ts"],
   },
-  resolve: {
-    alias: {
-      "@supergrain/kernel": resolve(__dirname, "../kernel/src"),
-      "@supergrain/kernel/react": resolve(__dirname, "../kernel/src/react"),
-      "@supergrain/silo": resolve(__dirname, "../silo/src"),
-    },
-  },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/js-krauset/vitest.config.ts
+++ b/packages/js-krauset/vitest.config.ts
@@ -1,7 +1,8 @@
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+const conditions = ["@supergrain/source"];
 
 export default defineConfig({
   plugins: [react()],
@@ -20,10 +21,6 @@ export default defineConfig({
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["src/dist.test.ts"],
   },
-  resolve: {
-    alias: {
-      "@supergrain/kernel": resolve(__dirname, "../kernel/src/index.ts"),
-      "@supergrain/kernel/react": resolve(__dirname, "../kernel/src/react/index.ts"),
-    },
-  },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -30,16 +30,19 @@
   "types": "./src/index.ts",
   "exports": {
     ".": {
+      "@supergrain/source": "./src/index.ts",
       "types": "./src/index.ts",
       "import": "./dist/index.es.js",
       "require": "./dist/index.cjs.js"
     },
     "./internal": {
+      "@supergrain/source": "./src/internal.ts",
       "types": "./src/internal.ts",
       "import": "./dist/internal.js",
       "require": "./dist/internal.cjs"
     },
     "./react": {
+      "@supergrain/source": "./src/react/index.ts",
       "types": "./src/react/index.ts",
       "import": "./dist/react/index.js",
       "require": "./dist/react/index.cjs"

--- a/packages/kernel/vitest.browser.config.ts
+++ b/packages/kernel/vitest.browser.config.ts
@@ -1,7 +1,8 @@
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+const conditions = ["@supergrain/source"];
 
 export default defineConfig({
   plugins: [react()],
@@ -20,9 +21,6 @@ export default defineConfig({
     setupFiles: ["./tests/react/setup.ts"],
     globals: true,
   },
-  resolve: {
-    alias: {
-      "@supergrain/kernel": resolve(__dirname, "./src"),
-    },
-  },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/kernel/vitest.config.ts
+++ b/packages/kernel/vitest.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from "vitest/config";
 
+const conditions = ["@supergrain/source"];
+
 export default defineConfig({
   test: {
     exclude: ["**/node_modules/**", "**/dist/**", "tests/react/**"],
     environmentMatchGlobs: [["tests/foreach-benchmark.test.tsx", "jsdom"]],
   },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/mill/package.json
+++ b/packages/mill/package.json
@@ -29,6 +29,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@supergrain/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"

--- a/packages/mill/tsconfig.json
+++ b/packages/mill/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "customConditions": ["@supergrain/source"],
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/mill/vitest.config.ts
+++ b/packages/mill/vitest.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vitest/config";
 
+const conditions = ["@supergrain/source"];
+
 export default defineConfig({
   test: {
     environment: "node",
   },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/queries/package.json
+++ b/packages/queries/package.json
@@ -29,6 +29,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@supergrain/source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"

--- a/packages/queries/tsconfig.json
+++ b/packages/queries/tsconfig.json
@@ -9,12 +9,7 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "baseUrl": ".",
-    "paths": {
-      "@supergrain/kernel": ["../kernel/src"],
-      "@supergrain/silo": ["../silo/src"]
-    }
+    "noUnusedParameters": true
   },
   "include": ["src", "tests"]
 }

--- a/packages/queries/vitest.browser.config.ts
+++ b/packages/queries/vitest.browser.config.ts
@@ -1,6 +1,7 @@
 import { playwright } from "@vitest/browser-playwright";
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+const conditions = ["@supergrain/source"];
 
 export default defineConfig({
   test: {
@@ -17,11 +18,6 @@ export default defineConfig({
     setupFiles: ["./tests/setup.ts"],
     globals: true,
   },
-  resolve: {
-    alias: {
-      "@supergrain/kernel": resolve(__dirname, "../kernel/src"),
-      "@supergrain/silo": resolve(__dirname, "../silo/src"),
-      "@supergrain/queries": resolve(__dirname, "./src"),
-    },
-  },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/packages/silo/package.json
+++ b/packages/silo/package.json
@@ -30,26 +30,31 @@
   "types": "./src/index.ts",
   "exports": {
     ".": {
+      "@supergrain/source": "./src/index.ts",
       "types": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./processors": {
+      "@supergrain/source": "./src/processors/index.ts",
       "types": "./src/processors/index.ts",
       "import": "./dist/processors/index.js",
       "require": "./dist/processors/index.cjs"
     },
     "./processors/json-api": {
+      "@supergrain/source": "./src/processors/json-api.ts",
       "types": "./src/processors/json-api.ts",
       "import": "./dist/processors/json-api.js",
       "require": "./dist/processors/json-api.cjs"
     },
     "./react": {
+      "@supergrain/source": "./src/react/index.ts",
       "types": "./src/react/index.ts",
       "import": "./dist/react/index.js",
       "require": "./dist/react/index.cjs"
     },
     "./react/json-api": {
+      "@supergrain/source": "./src/react/json-api.ts",
       "types": "./src/react/json-api.ts",
       "import": "./dist/react/json-api.js",
       "require": "./dist/react/json-api.cjs"

--- a/packages/silo/tsconfig.json
+++ b/packages/silo/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "customConditions": ["@supergrain/source"],
     "resolveJsonModule": true,
     "isolatedModules": true,
     "allowJs": true,

--- a/packages/silo/vitest.config.ts
+++ b/packages/silo/vitest.config.ts
@@ -1,14 +1,11 @@
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+const conditions = ["@supergrain/source"];
 
 export default defineConfig({
   test: {
     environment: "jsdom",
   },
-  resolve: {
-    alias: {
-      "@supergrain/kernel": resolve(__dirname, "../kernel/src"),
-      "@supergrain/mill": resolve(__dirname, "../mill/src"),
-    },
-  },
+  resolve: { conditions },
+  ssr: { resolve: { conditions } },
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,11 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    // `@supergrain/source` is a workspace-only export condition: it's opted into
+    // by this tsconfig and each package's vitest config so tooling resolves
+    // `@supergrain/*` imports to `src/` instead of `dist/`. npm consumers never
+    // set this condition and fall through to `import`/`require` → `dist/*`, so
+    // packages don't need to ship `src/` in `files`.
     "customConditions": ["@supergrain/source"],
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "customConditions": ["@supergrain/source"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,52 +1,44 @@
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
+
+// Routes every `@supergrain/*` import to source TypeScript. Matches
+// `customConditions` in tsconfig.json. Both `resolve.conditions` (main)
+// and `ssr.resolve.conditions` (node-env tests) must be set; vitest's
+// node/jsdom runs go through Vite's SSR resolver which has its own
+// condition list.
+const conditions = ["@supergrain/source"];
+const resolve = { conditions };
+const ssr = { resolve: { conditions } };
 
 export default defineConfig({
   test: {
     projects: [
-      // Node environment for kernel core tests (default)
       {
         test: {
           include: ["packages/kernel/tests/{core,read,write}/**/*.test.{ts,tsx}"],
           environment: "node",
         },
-        resolve: {
-          alias: {
-            "@supergrain/kernel": resolve(__dirname, "./packages/kernel/src"),
-            "@supergrain/mill": resolve(__dirname, "./packages/mill/src"),
-          },
-        },
+        resolve,
+        ssr,
       },
-      // Node environment for mill tests
       {
         test: {
           include: ["packages/mill/**/*.test.{ts,tsx}"],
           environment: "node",
         },
-        resolve: {
-          alias: {
-            "@supergrain/kernel": resolve(__dirname, "./packages/kernel/src"),
-            "@supergrain/mill": resolve(__dirname, "./packages/mill/src"),
-          },
-        },
+        resolve,
+        ssr,
       },
-      // jsdom environment for silo tests (store, finder, processors, React hooks)
       {
         plugins: [react()],
         test: {
           include: ["packages/silo/**/*.test.{ts,tsx}"],
           environment: "jsdom",
         },
-        resolve: {
-          alias: {
-            "@supergrain/kernel": resolve(__dirname, "./packages/kernel/src"),
-            "@supergrain/mill": resolve(__dirname, "./packages/mill/src"),
-          },
-        },
+        resolve,
+        ssr,
       },
-      // Browser environment for React tests (kernel/react subpath)
       {
         plugins: [react()],
         test: {
@@ -64,12 +56,8 @@ export default defineConfig({
           setupFiles: ["./packages/kernel/tests/react/setup.ts"],
           globals: true,
         },
-        resolve: {
-          alias: {
-            "@supergrain/kernel": resolve(__dirname, "./packages/kernel/src"),
-            "@supergrain/mill": resolve(__dirname, "./packages/mill/src"),
-          },
-        },
+        resolve,
+        ssr,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Adds a `@supergrain/source` export condition to every `@supergrain/*` package's `exports` map, pointing at `src/*.ts` alongside the existing `types`/`import`/`require` entries that point at `dist/`.
- Wires `customConditions: ["@supergrain/source"]` into the tsconfigs and `resolve.conditions` + `ssr.resolve.conditions` into every `vitest.config.ts`, so `tsc`, `vitest`, and IDE tooling all resolve workspace imports to source.
- Removes redundant `paths` blocks from `doc-tests` and `queries` tsconfigs — the `exports` map is now the single source of truth.

## Why
Workspace tests previously depended on `packages/*/dist` being built and in sync with `src/` — otherwise vitest resolved some imports to source and others to stale dist, producing two separate module instances. That broke anything that relied on module-level state (e.g. `kernel/src/profiler.ts`'s `export let` bindings: `enableProfiling()` swapped the counter in one instance while `mill` wrote to another). CI always built first, so main was green; local `pnpm test` failed silently after any kernel change.

npm consumers don't know the custom condition and fall through to `import`/`require` → `dist/*` exactly as before, so there's no change to published package behavior.

## Test plan
- [x] `rm -rf packages/*/dist && pnpm test` → 307/307 pass
- [x] `rm -rf packages/*/dist && pnpm typecheck` → all packages clean
- [x] `rm -rf packages/*/dist && pnpm run test:validate` → 5/5 pass
- [x] `pnpm lint` → 0 errors
- [x] Per-package `pnpm vitest run` in `kernel`, `mill`, `silo` with no dist → all pass
- [x] After `pnpm run build`: `pnpm test` still 307/307 (no regression for dist-based resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)