### PR TITLE
Add test for useHasManyIndividually with missing relationship

### DIFF
--- a/packages/silo/tests/react/json-api.test.tsx
+++ b/packages/silo/tests/react/json-api.test.tsx
@@ -473,6 +473,29 @@ describe("useHasManyIndividually", () => {
 
     expect(screen.getByTestId("cards").textContent).toBe("no cards");
   });
+
+  it("returns an empty array when the relationship is absent", () => {
+    const MissingRelationship = tracked(function MissingRelationship() {
+      const handles = useHasManyIndividually(
+        {
+          id: "s1",
+          type: "card-stack",
+          attributes: { title: "Stack" },
+          relationships: {},
+        } as any,
+        "cards",
+      );
+      return <span data-testid="cards">{handles.length}</span>;
+    });
+
+    render(
+      <Wrap>
+        <MissingRelationship />
+      </Wrap>,
+    );
+
+    expect(screen.getByTestId("cards").textContent).toBe("0");
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
Added a test case to verify that `useHasManyIndividually` correctly handles scenarios where a relationship is absent from the resource object.

## Changes
- Added test case "returns an empty array when the relationship is absent" to the `useHasManyIndividually` test suite
- The test verifies that when a resource has an empty `relationships` object (missing the expected relationship key), the hook returns an empty array with length 0
- This ensures the hook gracefully handles missing relationships without errors

## Implementation Details
The test creates a card-stack resource with an empty relationships object and confirms that calling `useHasManyIndividually` with a non-existent "cards" relationship returns an empty array, validating defensive behavior for incomplete or malformed API responses.

https://claude.ai/code/session_01Wxb8sNH4y57aGJydaW6Rpj