### PR TITLE
Type-soundness and formatting cleanup on top of #80

### DIFF
--- a/packages/js-krauset/package.json
+++ b/packages/js-krauset/package.json
@@ -1,40 +1,40 @@
 {
-    "name": "js-framework-benchmark-react-supergrain",
-    "version": "1.0.0",
-    "private": true,
-    "scripts": {
-        "dev": "vite",
-        "build-prod": "vite build",
-        "typecheck": "tsc --noEmit",
-        "test": "pnpm build-prod && vitest run --config vitest.dist.config.ts src/dist.test.ts",
-        "test:perf": "pnpm build-prod && vitest run --config vitest.dist.config.ts src/perf.test.ts --reporter=verbose 2>&1 | tee perf-results.txt",
-        "perf:stats": "npx tsx perf-stats.ts",
-        "perf:compare": "npx tsx perf-compare.ts",
-        "perf:profile": "pnpm build-prod && PROFILE=1 vitest run --config vitest.dist.config.ts src/perf.test.ts",
-        "perf:analyze": "node perf-profile.ts"
-    },
-    "dependencies": {
-        "@supergrain/kernel": "workspace:*",
-        "react": "19.2.4",
-        "react-dom": "19.2.4"
-    },
-    "devDependencies": {
-        "@rollup/plugin-strip": "^3.0.4",
-        "@types/node": "^22.18.3",
-        "@types/ramda": "^0.31.1",
-        "@types/react": "^19.1.13",
-        "@types/react-dom": "^19.1.9",
-        "@vitejs/plugin-react": "^4.7.0",
-        "@vitest/browser": "4.1.0",
-        "playwright": "^1.55.0",
-        "ramda": "^0.32.0",
-        "typescript": "^5.9.2",
-        "vite": "^7.1.5",
-        "vite-plugin-dts": "^4.5.4",
-        "vitest": "4.1.0"
-    },
-    "js-framework-benchmark": {
-        "frameworkVersionFromPackage": "react",
-        "frameworkHomeURL": "https://reactjs.org/"
-    }
+  "name": "js-framework-benchmark-react-supergrain",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build-prod": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "pnpm build-prod && vitest run --config vitest.dist.config.ts src/dist.test.ts",
+    "test:perf": "pnpm build-prod && vitest run --config vitest.dist.config.ts src/perf.test.ts --reporter=verbose 2>&1 | tee perf-results.txt",
+    "perf:stats": "npx tsx perf-stats.ts",
+    "perf:compare": "npx tsx perf-compare.ts",
+    "perf:profile": "pnpm build-prod && PROFILE=1 vitest run --config vitest.dist.config.ts src/perf.test.ts",
+    "perf:analyze": "node perf-profile.ts"
+  },
+  "dependencies": {
+    "@supergrain/kernel": "workspace:*",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@rollup/plugin-strip": "^3.0.4",
+    "@types/node": "^22.18.3",
+    "@types/ramda": "^0.31.1",
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^4.7.0",
+    "@vitest/browser": "4.1.0",
+    "playwright": "^1.55.0",
+    "ramda": "^0.32.0",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.5",
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "4.1.0"
+  },
+  "js-framework-benchmark": {
+    "frameworkVersionFromPackage": "react",
+    "frameworkHomeURL": "https://reactjs.org/"
+  }
 }

--- a/packages/js-krauset/perf-stats.ts
+++ b/packages/js-krauset/perf-stats.ts
@@ -91,7 +91,10 @@ for (const benchName of benchmarkNames) {
   const samples = runs.map((run: any) => run.results.find((r: any) => r.name === benchName));
   const benchmark: any = {};
   for (const key of numericKeys) {
-    benchmark[key] = stats(samples.map((s: any) => s[key]), trimCount);
+    benchmark[key] = stats(
+      samples.map((s: any) => s[key]),
+      trimCount,
+    );
   }
   output.benchmarks[benchName] = benchmark;
 }
@@ -99,7 +102,10 @@ for (const benchName of benchmarkNames) {
 const totalSamples = runs.map((run: any) => run.totals);
 output.totals = {} as any;
 for (const key of numericKeys.filter((k) => k in runs[0].totals)) {
-  output.totals[key] = stats(totalSamples.map((t: any) => t[key]), trimCount);
+  output.totals[key] = stats(
+    totalSamples.map((t: any) => t[key]),
+    trimCount,
+  );
 }
 
 const outPath = resolve(dir, `perf-stats-${name}.json`);

--- a/packages/kernel/src/collections.ts
+++ b/packages/kernel/src/collections.ts
@@ -25,6 +25,7 @@ import {
   getNodesIfExist,
   isWrappable,
   unwrap,
+  type ReactiveTagged,
   type Signal,
 } from "./core";
 import { profileSignalRead, profileSignalSkip, profileSignalWrite } from "./profiler";
@@ -108,7 +109,7 @@ function bumpVersionSignal(target: object): void {
 
 export function createReactiveMap<K, V>(rawTarget: Map<K, V>): Map<K, V> {
   // Primary proxy cache: $PROXY stored directly on the raw target.
-  const existing = (rawTarget as any)[$PROXY] as Map<K, V> | undefined;
+  const existing = (rawTarget as ReactiveTagged)[$PROXY] as Map<K, V> | undefined;
   if (existing) return existing;
   // Fallback for sealed Maps where defineProperty($PROXY) fails.
   const existingSealed = sealedCollectionCache.get(rawTarget) as Map<K, V> | undefined;
@@ -352,7 +353,7 @@ export function createReactiveMap<K, V>(rawTarget: Map<K, V>): Map<K, V> {
 
 export function createReactiveSet<T>(rawTarget: Set<T>): Set<T> {
   // Primary proxy cache: $PROXY stored directly on the raw target.
-  const existing = (rawTarget as any)[$PROXY] as Set<T> | undefined;
+  const existing = (rawTarget as ReactiveTagged)[$PROXY] as Set<T> | undefined;
   if (existing) return existing;
   // Fallback for sealed Sets where defineProperty($PROXY) fails.
   const existingSealed = sealedCollectionCache.get(rawTarget) as Set<T> | undefined;

--- a/packages/kernel/src/core.ts
+++ b/packages/kernel/src/core.ts
@@ -39,6 +39,7 @@ export interface ReactiveTagged {
   [$PROXY]?: object;
   [$NODE]?: DataNodes;
   [$TRACK]?: object;
+  [$MUTATORS]?: Record<string, (...args: Array<unknown>) => unknown>;
 }
 
 export type DataNodes = Record<PropertyKey, Signal<unknown>>;

--- a/packages/kernel/src/read.ts
+++ b/packages/kernel/src/read.ts
@@ -73,12 +73,8 @@ function trackArrayVersion(value: unknown): void {
 // Create (or retrieve) the per-array mutator wrapper cache stored as a hidden
 // $MUTATORS property on the raw array. Extracted to keep the proxy get handler
 // shallow enough to satisfy the max-depth lint rule.
-function getMutatorCache(
-  target: object,
-): Record<string, (...args: Array<unknown>) => unknown> {
-  let cache = (target as any)[$MUTATORS] as
-    | Record<string, (...args: Array<unknown>) => unknown>
-    | undefined;
+function getMutatorCache(target: object): Record<string, (...args: Array<unknown>) => unknown> {
+  let cache = (target as ReactiveTagged)[$MUTATORS];
   if (!cache) {
     cache = Object.create(null) as Record<string, (...args: Array<unknown>) => unknown>;
     try {


### PR DESCRIPTION
## Summary

Correctness and formatting cleanup on top of the kernel-allocations work in #80. **No perf changes** — strictly type-soundness, formatting, and one accidental indentation regression.

## What this fixes

### 1. `as any` casts regressing #76's type-soundness sweep

Three casts to `any` were introduced when adding intrusive symbol storage:

- `packages/kernel/src/collections.ts` — `createReactiveMap` and `createReactiveSet` use `(rawTarget as any)[$PROXY]` to read the intrusive cache.
- `packages/kernel/src/read.ts` — `getMutatorCache` uses `(target as any)[$MUTATORS]`.

The codebase already has a `ReactiveTagged` interface in `core.ts` for exactly this purpose, and #76 deliberately removed `as any` from this surface. Reintroducing them here was a regression.

Fix: route all three through `ReactiveTagged`, and add `[$MUTATORS]?` to the interface so the cast resolves to a real type instead of needing another `as any` to land somewhere.

### 2. `packages/js-krauset/package.json` indent regression

The base reformatted this file from 2-space to 4-space indentation. Every other `package.json` in the workspace uses 2-space, so this looks accidental. Reverted.

### 3. `perf-stats.ts` formatting

Two `stats(...)` calls added with `--trim` exceed the line width. `pnpm format` reformats them on a clean run, so committing them in formatted shape avoids future churn.

## What this is not

- No perf changes. No allocation refactors. No structural rewrites.
- The intrusive-symbol-cache work, the per-array `$MUTATORS` cache, the pre-created Map/Set methods — all kept exactly as the base has them.

## Validation

- `pnpm test` — kernel 175 / mill 52 pass
- `pnpm run typecheck` — clean
- `pnpm lint` — clean
- `pnpm format` — clean (no further reformatting needed)
- `pnpm run test:validate` — clean

https://claude.ai/code/session_01VDVFSh8xJqvYp61dZQ8q4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDVFSh8xJqvYp61dZQ8q4o)_