### PR TITLE
ci(release): switch npm publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,14 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
+      # pnpm 10.x delegates `pnpm publish` to the npm CLI. npm trusted
+      # publishing (OIDC) requires npm >= 11.5.1, so make sure the npm on PATH
+      # is recent enough regardless of what Node 24 happens to bundle.
+      - name: Ensure npm supports trusted publishing (OIDC)
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -47,5 +55,12 @@ jobs:
           commit: "Release: Version Packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN: authentication uses npm trusted publishing (OIDC).
+          # The job's `id-token: write` permission lets npm mint a short-lived,
+          # repo-scoped credential, so no long-lived token is needed. Each
+          # published package (@supergrain/kernel, @supergrain/mill,
+          # @supergrain/silo) must have a Trusted Publisher configured at
+          # npmjs.com pointing at commoncurriculum/supergrain + publish.yml.
+          # Provenance attestations are generated automatically on OIDC
+          # publishes; set it explicitly so intent is clear and verifiable.
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## What

Switches the `Release` workflow from a long-lived `NPM_TOKEN` to **npm trusted publishing over OIDC**, and enables provenance attestations.

## Why

[npm trusted publishing](https://docs.npmjs.com/trusted-publishers) lets CI authenticate to npm with a short-lived, repository-scoped OIDC credential instead of a stored token — no secret to leak, rotate, or accidentally over-scope. The release job already had `id-token: write`, so the plumbing was mostly in place.

## Changes (all in `.github/workflows/publish.yml`)

- **Remove `NPM_TOKEN` / `NODE_AUTH_TOKEN`** from the `changesets/action` step.
- **Ensure npm ≥ 11.5.1 on PATH** (the minimum npm version for trusted publishing). This repo pins **pnpm 10.6.3**, and pnpm 10.x delegates `pnpm publish` to the npm CLI — so the *npm* version is the thing that matters. pnpm's own native OIDC publish only landed in pnpm 11.0.0; staying on pnpm 10 keeps this change surgical and avoids the pnpm 11 migration (`strictDepBuilds`, `minimumReleaseAge`, `blockExoticSubdeps`, lockfile regen) that would touch every package.
- **Enable provenance** via `NPM_CONFIG_PROVENANCE: "true"`. All three published packages already have a `repository` field, which provenance requires.

## ⚠️ Required manual setup on npmjs.com before this can publish

Trusted publishing must be configured **per package** on the npm website. For **each** of `@supergrain/kernel`, `@supergrain/mill`, and `@supergrain/silo`, go to the package's **Settings → Trusted Publisher** and fill in:

| Field | Value |
|---|---|
| Publisher | GitHub Actions |
| Organization or user | `commoncurriculum` |
| Repository | `supergrain` |
| Workflow filename | `publish.yml` |
| Environment name | *(leave blank)* |
| Allowed actions | ☑ Allow `npm publish` |

### Safe rollout order
1. Configure the Trusted Publisher form for all three packages (above).
2. Keep **Publishing access** on *"Require 2FA **or** a granular access token"* — **do not** pick *"disallow tokens"* yet.
3. Merge this PR.
4. Confirm the next release publishes successfully over OIDC (check for the provenance badge on npm).
5. Once verified, optionally tighten **Publishing access** to *"disallow tokens"* and delete the now-unused `NPM_TOKEN` repo secret.

> Note: the npm screenshot that kicked this off was for `@supergrain/core`, which isn't published from this repo — the packages this workflow actually publishes are `kernel`, `mill`, and `silo`.

## Verification done here
- `publish.yml` validated as well-formed YAML.
- Confirmed `repository` field present on all three published packages (provenance prerequisite).
- `id-token: write` already granted on the release job.

---
_Generated by [Claude Code](https://claude.ai/code/session_012yM6Bb6ffMgpwupnudf7WP)_