### PR TITLE
ci(release): build all published packages + create GitHub Releases

### DIFF
--- a/.github/scripts/create-github-releases.mjs
+++ b/.github/scripts/create-github-releases.mjs
@@ -1,0 +1,115 @@
+// Create a GitHub Release (and its git tag) for each published @supergrain
+// package version that doesn't have one yet.
+//
+// Why this exists: the release workflow publishes with `pnpm -r publish` so the
+// `workspace:*` protocol is rewritten correctly (see pnpm "Using Changesets").
+// That command doesn't print the `New tag:` lines changesets/action looks for,
+// so the action can't create GitHub Releases. This script fills that gap.
+//
+// It is safe to run repeatedly: it only creates a Release when the package's
+// current version is actually live on npm AND no Release exists for that tag,
+// so it both publishes new releases and backfills any that were missed.
+//
+// Env: GITHUB_TOKEN (contents: write), GITHUB_REPOSITORY, GITHUB_SHA — all set
+// automatically by GitHub Actions.
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const token = process.env.GITHUB_TOKEN;
+const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? "").split("/");
+const sha = process.env.GITHUB_SHA;
+
+if (!token || !owner || !repo) {
+  console.error("Missing GITHUB_TOKEN / GITHUB_REPOSITORY env.");
+  process.exit(1);
+}
+
+const PACKAGES_DIR = "packages";
+
+async function gh(method, route, body) {
+  return fetch(`https://api.github.com${route}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// Pull the notes for `version` out of a package's CHANGELOG.md. Changesets
+// writes one `## <version>` heading per release, so slice between headings.
+function changelogNotes(pkgDir, version) {
+  const file = path.join(pkgDir, "CHANGELOG.md");
+  if (!existsSync(file)) return "";
+  const lines = readFileSync(file, "utf8").split("\n");
+  const start = lines.findIndex((l) => l.trim() === `## ${version}`);
+  if (start === -1) return "";
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines
+    .slice(start + 1, end)
+    .join("\n")
+    .trim();
+}
+
+async function isOnNpm(name, version) {
+  const res = await fetch(`https://registry.npmjs.org/${name}/${version}`, {
+    headers: { accept: "application/json" },
+  });
+  return res.ok;
+}
+
+let created = 0;
+let failed = 0;
+
+for (const entry of readdirSync(PACKAGES_DIR)) {
+  const dir = path.join(PACKAGES_DIR, entry);
+  const manifestPath = path.join(dir, "package.json");
+  if (!existsSync(manifestPath)) continue;
+
+  const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (pkg.private || !pkg.name?.startsWith("@supergrain/")) continue;
+
+  const tag = `${pkg.name}@${pkg.version}`;
+
+  if (!(await isOnNpm(pkg.name, pkg.version))) {
+    console.log(`· ${tag} — not on npm yet, skipping`);
+    continue;
+  }
+
+  const existing = await gh(
+    "GET",
+    `/repos/${owner}/${repo}/releases/tags/${encodeURIComponent(tag)}`,
+  );
+  if (existing.ok) {
+    console.log(`· ${tag} — release already exists, skipping`);
+    continue;
+  }
+
+  const res = await gh("POST", `/repos/${owner}/${repo}/releases`, {
+    tag_name: tag,
+    target_commitish: sha,
+    name: tag,
+    body: changelogNotes(dir, pkg.version) || `Release ${tag}`,
+  });
+
+  if (res.ok) {
+    console.log(`✓ created release ${tag}`);
+    created++;
+  } else {
+    console.error(`✗ failed to create ${tag}: ${res.status} ${await res.text()}`);
+    failed++;
+  }
+}
+
+console.log(`Done. Created ${created} release(s), ${failed} failure(s).`);
+if (failed > 0) process.exit(1);

--- a/.github/scripts/create-github-releases.mjs
+++ b/.github/scripts/create-github-releases.mjs
@@ -13,7 +13,8 @@
 // Env: GITHUB_TOKEN (contents: write), GITHUB_REPOSITORY, GITHUB_SHA — all set
 // automatically by GitHub Actions.
 
-import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const token = process.env.GITHUB_TOKEN;
@@ -61,11 +62,41 @@ function changelogNotes(pkgDir, version) {
     .trim();
 }
 
-async function isOnNpm(name, version) {
-  const res = await fetch(`https://registry.npmjs.org/${name}/${version}`, {
-    headers: { accept: "application/json" },
-  });
-  return res.ok;
+// The registry can be briefly eventually-consistent right after `npm publish`
+// (a version that was just published may 404 for a few seconds). Retry with
+// backoff so a fresh publish isn't mistaken for "not published".
+async function isOnNpm(name, version, { attempts = 6, baseDelayMs = 2000 } = {}) {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const res = await fetch(`https://registry.npmjs.org/${name}/${version}`, {
+        headers: { accept: "application/json" },
+      });
+      if (res.ok) return true;
+    } catch {
+      // network blip — fall through to retry
+    }
+    if (attempt < attempts) {
+      await new Promise((r) => setTimeout(r, baseDelayMs * attempt));
+    }
+  }
+  return false;
+}
+
+// Tags are effectively immutable once pushed, so point each Release at the
+// commit that actually introduced `version` (the changesets "Version Packages"
+// commit) rather than whatever commit happens to be running this workflow.
+// Otherwise backfilled Releases would be tagged at an unrelated later commit.
+// Requires full git history (checkout with fetch-depth: 0); falls back to the
+// current SHA if the commit can't be determined.
+function commitForVersion(pkgDir, version) {
+  const pattern = `"version": "${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`;
+  const result = spawnSync(
+    "git",
+    ["log", "-1", "--format=%H", "-G", pattern, "--", `${pkgDir}/package.json`],
+    { encoding: "utf8" },
+  );
+  const found = (result.stdout ?? "").trim();
+  return found || sha;
 }
 
 let created = 0;
@@ -97,7 +128,7 @@ for (const entry of readdirSync(PACKAGES_DIR)) {
 
   const res = await gh("POST", `/repos/${owner}/${repo}/releases`, {
     tag_name: tag,
-    target_commitish: sha,
+    target_commitish: commitForVersion(dir, pkg.version),
     name: tag,
     body: changelogNotes(dir, pkg.version) || `Release ${tag}`,
   });

--- a/.github/workflows/add-changeset.yml
+++ b/.github/workflows/add-changeset.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: 'Packages to release (comma-separated: kernel, mill, silo, or "all")'
+        description: 'Packages to release (comma-separated: kernel, mill, silo, husk, queries, or "all")'
         required: true
         type: string
         default: "all"
@@ -66,6 +66,8 @@ jobs:
             echo "\"@supergrain/kernel\": $BUMP_TYPE" >> "$CHANGESET_FILE"
             echo "\"@supergrain/mill\": $BUMP_TYPE" >> "$CHANGESET_FILE"
             echo "\"@supergrain/silo\": $BUMP_TYPE" >> "$CHANGESET_FILE"
+            echo "\"@supergrain/husk\": $BUMP_TYPE" >> "$CHANGESET_FILE"
+            echo "\"@supergrain/queries\": $BUMP_TYPE" >> "$CHANGESET_FILE"
           else
             # Split comma-separated packages
             IFS=',' read -ra PKGS <<< "$PACKAGES_INPUT"
@@ -81,6 +83,12 @@ jobs:
                   ;;
                 silo)
                   echo "\"@supergrain/silo\": $BUMP_TYPE" >> "$CHANGESET_FILE"
+                  ;;
+                husk)
+                  echo "\"@supergrain/husk\": $BUMP_TYPE" >> "$CHANGESET_FILE"
+                  ;;
+                queries)
+                  echo "\"@supergrain/queries\": $BUMP_TYPE" >> "$CHANGESET_FILE"
                   ;;
                 *)
                   echo "Warning: Unknown package '$pkg', skipping"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Full history so create-github-releases.mjs can resolve the commit
+          # that introduced each published version for the Release's tag.
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build packages
-        run: pnpm -r --filter="@supergrain/kernel" --filter="@supergrain/mill" --filter="@supergrain/silo" build
+        # Build every published package so each has a fresh dist/ before publish
+        # (dist is gitignored). The root `build` script is the single source of
+        # truth for "what gets published": kernel, mill, silo, husk, queries.
+        run: pnpm run build
 
       - name: Create Release Pull Request or Publish to NPM
         id: changesets
@@ -64,3 +67,16 @@ jobs:
           # Provenance attestations are generated automatically on OIDC
           # publishes; set it explicitly so intent is clear and verifiable.
           NPM_CONFIG_PROVENANCE: "true"
+
+      # `pnpm -r publish` (required for correct `workspace:*` rewriting) does not
+      # emit the `New tag:` output that changesets/action parses, so the action
+      # never creates GitHub Releases. Create them here instead: for every
+      # @supergrain package whose current version is live on npm and has no
+      # Release yet, tag the commit and publish release notes from its CHANGELOG.
+      # Idempotent, so it also backfills releases for previously-published
+      # versions. Runs only on the publish path (no pending changesets).
+      - name: Create GitHub Releases for published packages
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/scripts/create-github-releases.mjs

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "test:validate": "pnpm --filter @supergrain/doc-tests run test:validate",
-    "build": "pnpm --filter=\"@supergrain/kernel\" --filter=\"@supergrain/mill\" --filter=\"@supergrain/silo\" --workspace-concurrency=1 run build",
+    "build": "pnpm --filter=\"@supergrain/kernel\" --filter=\"@supergrain/mill\" --filter=\"@supergrain/silo\" --filter=\"@supergrain/husk\" --filter=\"@supergrain/queries\" --workspace-concurrency=1 run build",
     "bench:core": "vitest bench --root packages/kernel",
     "lint": "pnpm -r run lint",
     "size": "pnpm --filter=\"@supergrain/kernel\" run --sequential build && pnpm --filter=\"@supergrain/kernel\" run --sequential size",


### PR DESCRIPTION
Follow-up to #92. After trusted publishing went live, the `kernel@5.0.0` / `mill@5.0.0` publishes succeeded, but the run still went red and **`silo` (4.0.0) and `queries` (0.0.2) never published**, and no GitHub Releases were being created. This fixes both, plus the husk/queries drift.

## Root causes

1. **Build didn't cover all published packages.** `dist/` is gitignored, but the Build step only built `kernel`/`mill`/`silo`. `husk` and `queries` would publish without a fresh build.
2. **No GitHub Releases.** `pnpm -r publish` is the *correct* publish command — it rewrites the `workspace:*` protocol, which `changeset publish` does **not** ([pnpm docs](https://pnpm.io/using-changesets), [changesets#1389](https://github.com/changesets/changesets/discussions/1389)). But it doesn't emit the `New tag:` output that `changesets/action` parses, so the action never created Releases.

## Changes

- **`publish.yml` Build step → `pnpm run build`**, and the root `build` script now covers all five published packages (`kernel, mill, silo, husk, queries`) — one source of truth for "what ships."
- **New `.github/scripts/create-github-releases.mjs`** + a workflow step (runs on the publish path only). For every `@supergrain` package whose current version is live on npm and has no Release yet, it tags the commit and posts release notes pulled from that package's `CHANGELOG.md`. Idempotent → it also **backfills** the Releases missed for `kernel`/`mill`/`husk@5.0.0`.
- **`add-changeset.yml`** now includes `husk` and `queries` in its options (they were missing).

Kept `pnpm -r publish` deliberately — switching to `changeset publish` would publish broken packages with literal `workspace:*` deps.

## Verified locally
- `pnpm run build` builds all five packages to `dist/`. ✅
- `oxfmt --check .` (repo-wide) passes. ✅
- `node --check` on the new script; CHANGELOG section parser tested against `packages/mill/CHANGELOG.md` (extracts the `## 5.0.0` block, stops at the next heading). ✅
- Both workflow YAMLs validate.

## ⚠️ Before/after merging — to actually publish silo + queries

`pnpm -r publish` aborts on the first failure, so **every package it will touch needs a working Trusted Publisher on npm**, or the run dies partway again:

- `kernel`, `mill`, `husk` → already at 5.0.0 on npm, so they're **skipped** on the next run.
- `silo` (→5.0.0) and `queries` (→5.0.0) → **will publish**, but each needs its Trusted Publisher configured. `silo` was set up earlier; **`queries` still needs its form** (org `commoncurriculum`, repo `supergrain`, workflow `publish.yml`).

Once `queries`' Trusted Publisher exists, merging this PR triggers the Release workflow with no pending changesets → it builds all five → `pnpm -r publish` publishes `silo` + `queries` → the new step creates GitHub Releases for all five (including backfilling the three already published).

## Cutting releases from here on
1. Add a changeset (`pnpm changeset`, or the **Add Changeset** workflow).
2. Merge to `main` → the Release workflow opens a **"Release: Version Packages"** PR (version bumps + CHANGELOGs). All five bump together (`fixed` group in `.changeset/config.json`).
3. Merge that PR → packages publish to npm **and** get GitHub Releases automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_012yM6Bb6ffMgpwupnudf7WP)_