### PR TITLE
docs: add @supergrain/queries README and refresh package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ pnpm add @supergrain/kernel @supergrain/husk
 
 # State + API queries
 pnpm add @supergrain/kernel @supergrain/silo
+
+# ...plus paginated / live-subscription queries
+pnpm add @supergrain/kernel @supergrain/silo @supergrain/queries
 ```
 
 React bindings ship at `@supergrain/<pkg>/react` subpaths and require `react >= 18.2`.
@@ -251,6 +254,7 @@ React bindings ship at `@supergrain/<pkg>/react` subpaths and require `react >= 
 ## Also available
 
 - **[@supergrain/husk](./packages/husk/README.md)** — Reactive side-effect primitives: `resource`, `defineResource`, `reactivePromise`, `reactiveTask`, `dispose`, plus the `modifier` / `useModifier` DOM primitive. Layer between kernel's reactive core and application data layers.
+- **[@supergrain/queries](./packages/queries/README.md)** — Pagination + live-subscription queries built on `@supergrain/silo`. A reactive `createQuery` handle that pages through a resource, merges each page into the store, and refetches when the server signals staleness — on the same fetch engine as a silo document `find`.
 - **[@supergrain/mill](./packages/mill/README.md)** — MongoDB-style update operators (`$set`, `$inc`, `$push`, `$pull`, `$addToSet`, `$min`, `$max`, `$unset`) for batched, path-aware writes. Optional — plain `store.x = 1` is the usual path; reach for `mill` when you want to apply several updates atomically or use dot notation for deeply nested writes.
 
 ## Comparison

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,6 +16,8 @@ export default defineConfig({
       { text: "Home", link: "/" },
       { text: "Husk", link: "/husk" },
       { text: "Silo", link: "/silo" },
+      { text: "Queries", link: "/queries" },
+      { text: "Mill", link: "/mill" },
       { text: "Comparison", link: "/comparison" },
     ],
 

--- a/docs/mill.md
+++ b/docs/mill.md
@@ -1,0 +1,1 @@
+<!--@include: ../packages/mill/README.md-->

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,0 +1,1 @@
+<!--@include: ../packages/queries/README.md-->

--- a/packages/kernel/README.md
+++ b/packages/kernel/README.md
@@ -382,9 +382,9 @@ React features that trip up many state libraries — concurrent rendering, Suspe
 ## FAQ
 
 <details>
-<summary><strong>Why isn't my class instance / <code>Map</code> / <code>Set</code> reactive?</strong></summary>
+<summary><strong>Why isn't my class instance / <code>Date</code> / <code>RegExp</code> reactive?</strong></summary>
 
-Supergrain only proxies plain objects (`Object` constructor) and arrays. Class instances, `Map`, `Set`, `Date`, `RegExp`, and other built-ins pass through unchanged — they won't trigger re-renders when mutated. Store plain JSON-like data in your store; keep class instances and collections outside it. We may add `Map`/`Set` support in a later release.
+Supergrain proxies plain objects (including null-prototype), arrays, `Map`, and `Set` — reading and mutating any of them (`map.set(k, v)`, `set.add(x)`, `map.get(k)`) is tracked. Class instances, `Date`, `RegExp`, functions, and other built-ins pass through unchanged — they won't trigger re-renders when mutated. Store plain JSON-like data (objects, arrays, `Map`s, `Set`s) in your store; keep class instances outside it.
 
 </details>
 

--- a/packages/queries/README.md
+++ b/packages/queries/README.md
@@ -11,10 +11,10 @@ Pagination + live-subscription queries for [`@supergrain/silo`](../silo/README.m
 ## Install
 
 ```bash
-pnpm add @supergrain/queries @supergrain/silo @supergrain/kernel
+pnpm add @supergrain/queries @supergrain/silo @supergrain/kernel effect
 ```
 
-`effect` is a peer dependency (installed transitively; you don't have to write Effect to use it).
+`effect` is a peer dependency of `@supergrain/silo` and `@supergrain/queries` — install it alongside (shown above). It's the engine silo runs on; you don't have to write any Effect yourself.
 
 ## Why a separate package?
 
@@ -46,9 +46,14 @@ type Models = {
 const store: DocumentStore<Models> = createDocumentStore<Models>({
   models: {
     // `createQuery` owns this slot's fetching through its own QueryAdapter, so the
-    // model adapter here is a never-called placeholder — required only because
-    // every declared type needs a `models` entry.
-    planbooks_for_user: { adapter: { find: () => Promise.resolve([]) } },
+    // model adapter here is never called. It throws so a stray
+    // `store.find("planbooks_for_user", id)` fails loudly instead of silently
+    // returning the wrong shape — every declared type still needs a `models` entry.
+    planbooks_for_user: {
+      adapter: {
+        find: () => Promise.reject(new Error("planbooks_for_user is driven by createQuery")),
+      },
+    },
     // `planbook` has a real adapter so `useDocument("planbook", id)` works too.
     planbook: {
       adapter: {
@@ -123,7 +128,7 @@ const PlanbookList = tracked(({ userId }: { userId: string }) => {
         ))}
       </ul>
       {query.nextOffset !== null && (
-        <button disabled={query.isFetching} onClick={() => query.fetchNextPage()}>
+        <button disabled={query.isFetching} onClick={() => void query.fetchNextPage()}>
           {query.isFetching ? "Loading…" : "Load more"}
         </button>
       )}

--- a/packages/queries/README.md
+++ b/packages/queries/README.md
@@ -1,0 +1,230 @@
+# @supergrain/queries
+
+Pagination + live-subscription queries for [`@supergrain/silo`](../silo/README.md). A reactive `createQuery` handle that pages through a resource, merges each page into the store, and refetches when the server says the results are stale — running on the **same Effect engine** as a silo document fetch.
+
+- **Paginated** — `fetchNextPage()` merges pages by server-provided offset; `refetch()` replaces from page 0.
+- **Lives in the store** — results, the next-page cursor, and sideloaded `included` docs are written into your `DocumentStore`, so they're reactive and normalized alongside everything else.
+- **Same resilience as a document fetch** — `retry` / `timeout` / `deadline` / `retryable` resolve through the store exactly like a `ModelConfig`; failures report to the store's `onError` sink and count against `maxConcurrency`.
+- **Single-flight** — a `refetch()` interrupts any in-flight fetch (aborting its adapter `signal`); `fetchNextPage()` instead waits for one, so a fresher page 0 is never silently dropped.
+- **Live, opt-in** — pass a `subscribe` hook (typically your socket transport); when the server signals staleness, the query refetches from offset 0.
+
+## Install
+
+```bash
+pnpm add @supergrain/queries @supergrain/silo @supergrain/kernel
+```
+
+`effect` is a peer dependency (installed transitively; you don't have to write Effect to use it).
+
+## Why a separate package?
+
+`@supergrain/silo` caches one response per `(type, id)` document or `(type, params)` query — perfect for entities and one-shot results. Some resources have a different shape: an **append-only, paginated feed** that grows as you scroll and goes stale when the server pushes an update — a user's planbooks, a search result set, an activity stream. `@supergrain/queries` is the primitive for that shape. It accumulates the pages in a single store slot and hands back a reactive handle to drive it, reusing silo's fetch engine rather than re-implementing retries, abort, and telemetry.
+
+## Usage
+
+A query result is stored as one `(type, id)` slot whose value is a `QueryModel` — the accumulated `results` plus the next-page cursor. Declare that slot in your store's `DocumentTypes`, then drive it with `createQuery`.
+
+```ts
+import { createDocumentStore, type DocumentStore } from "@supergrain/silo";
+import { createQuery, type QueryAdapter, type QueryModel } from "@supergrain/queries";
+
+// Each result item carries its own server-assigned `offset` (stable positioning
+// across pages).
+interface PlanbookRef {
+  type: "planbook";
+  id: string;
+  offset: number;
+}
+
+type Models = {
+  // The query slot: its value is a QueryModel of PlanbookRefs, keyed by user id.
+  planbooks_for_user: QueryModel<"planbooks_for_user", PlanbookRef>;
+  // A normal document — sideloaded by the query's `included`, readable directly.
+  planbook: { id: string; type: "planbook"; title: string };
+};
+
+const store: DocumentStore<Models> = createDocumentStore<Models>({
+  models: {
+    // `createQuery` owns this slot's fetching through its own QueryAdapter, so the
+    // model adapter here is a never-called placeholder — required only because
+    // every declared type needs a `models` entry.
+    planbooks_for_user: { adapter: { find: () => Promise.resolve([]) } },
+    // `planbook` has a real adapter so `useDocument("planbook", id)` works too.
+    planbook: {
+      adapter: {
+        find: (ids) =>
+          Promise.all(ids.map((id) => fetch(`/api/planbooks/${id}`).then((r) => r.json()))),
+      },
+    },
+  },
+});
+
+// The adapter pages the resource. Return a Promise (a rejection becomes an
+// AdapterError) or an Effect to own the failure channel. `signal` aborts when the
+// run is interrupted — a timeout fires, a retry abandons the prior attempt, or the
+// query is destroyed / superseded.
+const adapter: QueryAdapter<PlanbookRef> = {
+  fetch: (userId, { offset, limit, signal }) =>
+    fetch(`/api/users/${userId}/planbooks?offset=${offset}&limit=${limit}`, { signal }).then((r) =>
+      r.json(),
+    ),
+};
+
+const query = createQuery({ store, adapter, type: "planbooks_for_user", id: "u1" });
+
+await query.refetch(); // fetch page 0
+query.results; // PlanbookRef[] — reactive, lives in the store
+query.nextOffset; // number | null
+
+if (query.nextOffset !== null) await query.fetchNextPage(); // merge the next page
+
+query.destroy(); // interrupt any in-flight fetch and unsubscribe
+```
+
+The adapter resolves a fixed **response envelope**:
+
+```ts
+interface QueryEnvelope<T> {
+  data: { results: Array<T> }; // this page's items; each carries its own `offset`
+  meta?: { nextOffset?: number | null }; // cursor for the next page, null when exhausted
+  included?: Array<{ type: string; id: string }>; // sideloaded docs (JSON-API style)
+}
+```
+
+Each `included` item must carry its own `type` and `id`; the query inserts it into the store under that type via `insertDocument`, so a sibling `useDocument("planbook", id)` reads the same normalized object — no extra fetch.
+
+### In React
+
+`createQuery` is framework-agnostic, but its fields are reactive, so read them inside a `tracked()` component and they drive fine-grained re-renders. Create the query once and destroy it on unmount:
+
+```tsx
+import { useEffect, useMemo } from "react";
+import { tracked } from "@supergrain/kernel/react";
+import { createQuery } from "@supergrain/queries";
+import { useDocumentStore } from "./store"; // from createDocumentStoreContext
+
+const PlanbookList = tracked(({ userId }: { userId: string }) => {
+  const store = useDocumentStore();
+  const query = useMemo(
+    () => createQuery({ store, adapter, type: "planbooks_for_user", id: userId }),
+    [store, userId],
+  );
+
+  useEffect(() => {
+    void query.refetch();
+    return () => query.destroy();
+  }, [query]);
+
+  return (
+    <>
+      <ul>
+        {query.results.map((r) => (
+          <li key={r.id}>{r.id}</li>
+        ))}
+      </ul>
+      {query.nextOffset !== null && (
+        <button disabled={query.isFetching} onClick={() => query.fetchNextPage()}>
+          {query.isFetching ? "Loading…" : "Load more"}
+        </button>
+      )}
+    </>
+  );
+});
+```
+
+For automatic lifecycle ownership (abort on rerun, dispose on unmount), the same pattern composes with [`@supergrain/husk`](../husk/README.md)'s `useResource` / `defineResource`.
+
+### Pagination semantics
+
+Matches the Ember `live-query` helper:
+
+- **`refetch()`** fetches from offset 0 and replaces the results array wholesale, preserving the server's response order.
+- **`fetchNextPage()`** fetches from the stored `nextOffset` (or 0 if none yet) and **sparse-merges** by each result's server `offset` (`results[result.offset] = result`) on top of the existing array.
+- An **empty** response at any offset resets the results array to `[]`.
+
+### Resilience — inherited from the store
+
+A query fetch goes through `store.runAdapter`, the same boundary a document `find` uses. With no per-query overrides it inherits the store's resolved defaults (the built-in jittered-fibonacci `defaultRetry` bounded by the 2-minute `defaultDeadline`). Override per query — the same knobs as `ModelConfig`:
+
+```ts
+import { Duration, Schedule } from "effect";
+
+createQuery({
+  store,
+  adapter,
+  type: "planbooks_for_user",
+  id: "u1",
+  limit: 50, // page size (default 200)
+  retry: Schedule.recurs(3), // or Schedule.recurs(0) to disable
+  timeout: Duration.seconds(10), // bounds a single attempt
+  deadline: Duration.seconds(30), // bounds all attempts together (incl. backoff)
+});
+```
+
+Every failed attempt (and a terminal failure) reports to the store's `onError` sink, and the fetch counts against the store's `maxConcurrency` — exactly like a document fetch. `Query.error` is the same typed `SiloError` channel as a silo handle: a rejected `Promise` adapter surfaces as an `AdapterError` (original rejection on `.cause`); a malformed envelope or a frozen-doc insert surfaces as a `ProcessorError`.
+
+### Live subscription
+
+Pass a `subscribe` hook — typically wrapping your socket transport. It's called once on init with `(type, id, onInvalidate)` and must return an unsubscribe function (invoked by `destroy()`). Call `onInvalidate` whenever the server signals the results are stale; the query refetches from offset 0.
+
+```ts
+createQuery({
+  store,
+  adapter,
+  type: "planbooks_for_user",
+  id: "u1",
+  subscribe: (type, id, onInvalidate) => {
+    const channel = socket.subscribe(`${type}:${id}`, () => onInvalidate());
+    return () => channel.unsubscribe();
+  },
+});
+```
+
+### Single-flight
+
+A new `refetch()` (or `destroy()`) interrupts any in-flight fetch — its adapter `signal` aborts — so overlapping requests can't race to write the store. `fetchNextPage()` instead waits for an in-flight fetch (superseding it would silently drop a fresher page 0 and merge the next page onto stale results), then reads `nextOffset` from what actually landed. A superseded run's returned promise follows its replacement, so `await refetch()` always reflects the state the query settled into.
+
+## API
+
+### `createQuery(params): Query<T>`
+
+`params` (`CreateQueryParams`):
+
+| Field                                          | Type                                     | Notes                                                                       |
+| ---------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------- |
+| `store`                                        | `DocumentStore<M>`                       | Store to read results from and write pages into.                            |
+| `adapter`                                      | `QueryAdapter<T>`                        | Pages the resource. Promise- or Effect-returning.                           |
+| `type`                                         | `keyof M & string`                       | The query slot type (a key of the store's `DocumentTypes`).                 |
+| `id`                                           | `string`                                 | The slot id — the query's parameter (e.g. a user id).                       |
+| `limit?`                                       | `number`                                 | Page size. Default `200`.                                                   |
+| `retry` / `timeout` / `deadline` / `retryable` | (same as `ModelConfig`)                  | Per-fetch resilience overrides; resolved per-query → store-wide → built-in. |
+| `subscribe?`                                   | `(type, id, onInvalidate) => () => void` | Opt-in live-invalidation hook; return its unsubscribe.                      |
+
+### `Query<T>`
+
+The reactive handle returned by `createQuery`:
+
+- `results: Array<T>` — accumulated page items (reactive; read from the store).
+- `nextOffset: number | null` — cursor for the next page, `null` when exhausted.
+- `isFetching: boolean` — a fetch is in flight.
+- `error: SiloError | undefined` — the last settled fetch's typed failure. Like a silo handle, a previous error stays visible while a refetch is in flight; it clears (or is replaced) when the fetch settles.
+- `failureCount: number` — failed attempts in the current fetch cycle, reset to 0 on success.
+- `lastError: SiloError | undefined` — the latest attempt's error while retrying.
+- `fetchNextPage(): Promise<void>` — fetch + merge the next page using the stored `nextOffset` (or 0).
+- `refetch(): Promise<void>` — refetch from offset 0, replacing the results array.
+- `destroy(): void` — interrupt any in-flight fetch (aborting its adapter `signal`) and unsubscribe.
+
+### Types
+
+- `QueryAdapter<T>` — `{ fetch(id, { offset, limit, signal? }): Promise<QueryEnvelope<T>> | Effect<QueryEnvelope<T>, AdapterError> }`.
+- `QueryEnvelope<T>` — the fixed response shape (`data.results`, optional `meta.nextOffset`, optional `included`).
+- `QueryModel<K, T>` — `{ id: string; type: K; results: Array<T>; nextOffset: number | null }` — the value stored under `(type, id)`. Declare it in your `DocumentTypes`.
+- `CreateQueryParams<M, K, T>` — the params object above.
+
+## Relationship to silo
+
+`@supergrain/silo` already has params-keyed queries (`useQuery` / `findQuery`) for one-shot, whole-response results. Reach for `@supergrain/queries` when the result is a **growing, paginated** list that you also want to **live-refresh** — it layers those two behaviors on top of the same store, sharing silo's fetch engine, error channel, and telemetry rather than re-implementing them.
+
+## License
+
+MIT

--- a/packages/queries/README.md
+++ b/packages/queries/README.md
@@ -116,7 +116,7 @@ const PlanbookList = tracked(({ userId }: { userId: string }) => {
   );
 
   useEffect(() => {
-    void query.refetch();
+    query.refetch();
     return () => query.destroy();
   }, [query]);
 
@@ -128,7 +128,7 @@ const PlanbookList = tracked(({ userId }: { userId: string }) => {
         ))}
       </ul>
       {query.nextOffset !== null && (
-        <button disabled={query.isFetching} onClick={() => void query.fetchNextPage()}>
+        <button disabled={query.isFetching} onClick={() => query.fetchNextPage()}>
           {query.isFetching ? "Loading…" : "Load more"}
         </button>
       )}

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -627,9 +627,9 @@ These aren't "same library, different maturity" — they're genuinely different 
 | Invalidation                                           |     ✓      |           ✗            | add `invalidate` / `invalidateType`            |
 | Stale-time / gc-time                                   |     ✓      |           ✗            | add `staleMs`; compare against `fetchedAt`     |
 | Refetch on focus / reconnect / interval                |     ✓      |           ✗            | add opt-in hooks                               |
-| Retry with backoff                                     |     ✓      |           ✗            | add to Finder                                  |
-| Cancellation                                           |     ✓      |           ✗            | thread `AbortSignal` through adapter           |
-| Pagination / infinite queries                          |     ✓      |           ✗            | wrapper hook that extends an id-list           |
+| Retry with backoff                                     |     ✓      |           ✓            | — (jittered fibonacci default; configurable)   |
+| Cancellation                                           |     ✓      |           ✓            | — (adapter `AbortSignal`; not on unmount)      |
+| Pagination / infinite queries                          |     ✓      |           ✗            | `@supergrain/queries` (shipped)                |
 | Mutations + optimistic + rollback                      |     ✓      |           ✗            | next-PR write layer built on `insertDocument`  |
 | SSR / hydration                                        |     ✓      |           ✗            | serialize the store's reactive tree, rehydrate |
 | Persistence (localStorage / IDB)                       |     ✓      |           ✗            | serialize map on write, restore on init        |
@@ -640,7 +640,7 @@ These aren't "same library, different maturity" — they're genuinely different 
 
 ### What we give up vs TQ
 
-- **Shipped feature count.** TQ has years of polish; we're shipping a read layer. If you need stale-time, refetch-on-focus, mutations, or pagination _today_, TQ wins.
+- **Shipped feature count.** TQ has years of polish; we're shipping a read layer. If you need stale-time, refetch-on-focus, or mutations _today_, TQ wins. (Retry/backoff, cancellation, and pagination have since landed — pagination ships separately in [`@supergrain/queries`](../queries/README.md).)
 - **Partial-key pattern invalidation.** `invalidateQueries({ queryKey: ['users'] })` in TQ matches every key starting with `['users']`. Our planned `invalidateType('users-by-role')` is blunter — drops everything under a type in one call. Predicate invalidation (`invalidateWhere`) handles the precise cases. Net: ~5% of real-world invalidation needs are less ergonomic.
 - **Zero-discipline fetching.** Write `queryFn` and you're done. Here you write adapter + processor + provider wiring. More up-front work; pays off if normalization matters to you.
 - **Mature ecosystem.** Persisters, devtools, SSR integrations, community plugins.
@@ -655,7 +655,7 @@ These aren't "same library, different maturity" — they're genuinely different 
 
 ### When to pick which
 
-- **Pick TQ today** if you need stale-time, refetch, mutations, or pagination _shipping now_. If "opaque cache, refetch on events" fits your mental model and you don't want to think about normalization. If your queries don't overlap enough for cross-query sync to matter.
+- **Pick TQ today** if you need stale-time, refetch-on-focus, or mutations _shipping now_. If "opaque cache, refetch on events" fits your mental model and you don't want to think about normalization. If your queries don't overlap enough for cross-query sync to matter.
 - **Pick document-store** if you want fine-grained reactive state as your primary model and documents should be part of that. If cross-query sync would meaningfully simplify your app (entity updates radiating without keys). If you're okay being on a library with a smaller feature surface today, trusting that the additive features will land.
 - **Use both in one app during migration.** Totally viable. TQ for search/list/cursor queries where opacity is fine; document-store for entity reads that benefit from normalization. They don't step on each other.
 
@@ -669,10 +669,9 @@ These are deliberate — every one was considered and left out for this read lay
 
 - Writes, dispatch, optimistic updates — a separate write layer will build on this.
 - Stale-time / refetch-on-focus / background revalidation.
-- Imperative `handle.refetch()` — observe fresh data by calling `insertDocument` from a socket handler or a mutation response.
-- Retry with backoff.
-- Server-push invalidation.
-- Cancellation of in-flight fetches.
+- Imperative `handle.refetch()` on a document — observe fresh data by calling `insertDocument` from a socket handler or a mutation response. (Paginated queries in [`@supergrain/queries`](../queries/README.md) do expose `refetch()` / `fetchNextPage()`.)
+- Server-push invalidation for individual documents — push fresh data with `insertDocument` instead. ([`@supergrain/queries`](../queries/README.md) adds an opt-in `subscribe` hook for paginated queries.)
+- Unmount-driven cancellation — an in-flight fetch completes and populates the cache even after its component unmounts. Adapters still receive an `AbortSignal` that fires on `timeout` / `deadline` / interrupt, so request cancellation itself is supported.
 - **Auto-suspending hooks.** `useDocument` returns a handle; it never throws to Suspense on its own. Suspense is a one-line opt-in (`use(handle.promise)`). The reverse — recovering a handle from an auto-suspending hook — isn't possible, so the primitive stays non-suspending and auto-suspend is a trivial wrapper anyone can write.
 
 ## License


### PR DESCRIPTION
## What

Documentation pass: a new README for `@supergrain/queries`, a sweep of the existing package READMEs for staleness, and the public docs site updated so every published package is covered.

### 1. New `packages/queries/README.md`
`@supergrain/queries` had no README. Added one documenting `createQuery` (the pagination + live-subscription primitive built on `@supergrain/silo`):
- What it's for and why it's a separate package from silo's params-keyed queries
- Usage: declaring the `QueryModel` slot in `DocumentTypes`, the `QueryAdapter` + fixed `QueryEnvelope` response shape, sideloaded `included` docs
- React wiring (`tracked` + create-once/destroy-on-unmount)
- Pagination semantics (`refetch` replaces page 0, `fetchNextPage` sparse-merges by server offset, empty response resets)
- Store-inherited resilience (`retry` / `timeout` / `deadline` / `retryable`, `onError`, `maxConcurrency`)
- Live `subscribe` hook, single-flight behavior, and a full API reference (`createQuery`, `Query<T>`, `QueryAdapter`, `QueryEnvelope`, `QueryModel`, `CreateQueryParams`)

### 2. READMEs brought up to date
- **kernel:** the FAQ still said `Map`/`Set` aren't reactive and "we may add support later" — but reactive Map/Set shipped (#73). Updated to reflect that plain objects, arrays, `Map`, and `Set` are proxied; only class instances / `Date` / `RegExp` / functions pass through.
- **silo:** the TanStack Query comparison table and "Non-goals" still listed retry-with-backoff and cancellation as ✗ / non-goals, contradicting the API section after the 5.0.0 shared-engine work. Marked retry/backoff and request cancellation (adapter `AbortSignal`) as shipped, pointed the pagination row at `@supergrain/queries`, removed the stale "Retry with backoff" non-goal, and clarified that the remaining cancellation non-goal is specifically *unmount-driven* cancellation.

### 3. Public docs (VitePress)
- Surfaced `@supergrain/queries` in the root README ("Also available" + install snippet).
- Added **Queries** and **Mill** pages to the docs nav (`docs/queries.md`, `docs/mill.md` include their package READMEs), so every published package now has a docs page — previously Mill and Queries were absent from the site.

## Verification
- `pnpm run test:validate` — ✅ README doc-test linkage (queries README uses `ts`/`tsx` fences, so no new DOC_TEST identifiers required)
- `pnpm run typecheck` — ✅
- `pnpm lint` — ✅
- `pnpm format` / `format:check` — ✅
- `pnpm run docs:build` — ✅ site builds; new `queries.html` and `mill.html` render with expected content

Docs-only change (no shipped source touched). Since `prepack` copies the root README into each package at publish time, these per-package READMEs are GitHub + docs-site facing, so no changeset is needed.

https://claude.ai/code/session_01R7Bg7w1Cfcm6AysURbWMyB

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7Bg7w1Cfcm6AysURbWMyB)_