### PR TITLE
feat(silo): ordered response-processor pipeline

### DIFF
--- a/.changeset/silo-processor-pipeline.md
+++ b/.changeset/silo-processor-pipeline.md
@@ -25,7 +25,7 @@ cramming every responsibility into one processor.
 **Ordered pipeline semantics.** Silo passes the adapter response through each
 processor in order. A processor may mutate the response, **return a replacement
 response** (handed to later processors), perform side effects, or insert
-documents. Returning `undefined` passes the current response through unchanged.
+documents. Returning `undefined` (or `null`) passes the current response through unchanged.
 A throw stops the pipeline (the remaining processors don't run) and fails the
 chunk with a `ProcessorError` — the same terminal behavior as a single
 `processor` throw.

--- a/.changeset/silo-processor-pipeline.md
+++ b/.changeset/silo-processor-pipeline.md
@@ -2,10 +2,11 @@
 "@supergrain/silo": minor
 ---
 
-Add an ordered response-processor pipeline to `ModelConfig`.
+Add an ordered response-processor pipeline to both surfaces — `ModelConfig`
+(documents) and `QueryConfig` (queries).
 
-A model can now declare `processors: ResponseProcessor[]` — an ordered pipeline
-run in declared order after `adapter.find(ids)` resolves. This makes the fetch
+A model or query can now declare `processors: [...]` — an ordered pipeline run
+in declared order after `adapter.find(...)` resolves. This makes the fetch
 lifecycle explicit and lets applications compose response work in execution
 order (migrate → mirror into another store → insert into silo) instead of
 cramming every responsibility into one processor.
@@ -36,11 +37,17 @@ normalized to a one-element pipeline, so `{ adapter }`,
 **both** `processor` and `processors` on the same model is a configuration error
 and throws at store creation.
 
-**`ResponseProcessor` signature.** Its shape is now
-`(response, context) => unknown | void`, where `context` is
-`{ store, type, ids }` (previously `(raw, store, type) => void`). The bundled
-`defaultProcessor` / `jsonApiProcessor` and every config that uses them are
-unaffected; hand-written custom processors that relied on the old positional
-`(raw, store, type)` arguments should read `store` / `type` off the context
-object and can now return a replacement response. A new `ProcessorContext` type
-is exported for typing custom processors.
+**Processor signatures.** Both processor types now have the shape
+`(response, context) => unknown | void`:
+
+- `ResponseProcessor` (documents): `context` is `{ store, type, ids }`
+  (previously `(raw, store, type) => void`).
+- `QueryProcessor` (queries): `context` is `{ store, type, paramsList }`
+  (previously `(raw, store, type, paramsList) => void`).
+
+The bundled `defaultProcessor` / `jsonApiProcessor` / `defaultQueryProcessor`
+and every config that uses them are unaffected; hand-written custom processors
+that relied on the old positional arguments should read `store` / `type` /
+`paramsList` off the context object and can now return a replacement response.
+New `ProcessorContext` and `QueryProcessorContext` types are exported for typing
+custom processors.

--- a/.changeset/silo-processor-pipeline.md
+++ b/.changeset/silo-processor-pipeline.md
@@ -25,10 +25,11 @@ cramming every responsibility into one processor.
 **Ordered pipeline semantics.** Silo passes the adapter response through each
 processor in order. A processor may mutate the response, **return a replacement
 response** (handed to later processors), perform side effects, or insert
-documents. Returning `undefined` (or `null`) passes the current response through unchanged.
-A throw stops the pipeline (the remaining processors don't run) and fails the
-chunk with a `ProcessorError` — the same terminal behavior as a single
-`processor` throw.
+documents. Returning `undefined` — or `null` — passes the current response
+through unchanged (pass-through uses `??`, so `null` can't be used to replace
+the response). A throw stops the pipeline (the remaining processors don't run)
+and fails the chunk with a `ProcessorError` — the same terminal behavior as a
+single `processor` throw.
 
 **Backward compatible config.** The single `processor` field still works and is
 normalized to a one-element pipeline, so `{ adapter }`,

--- a/.changeset/silo-processor-pipeline.md
+++ b/.changeset/silo-processor-pipeline.md
@@ -1,0 +1,46 @@
+---
+"@supergrain/silo": minor
+---
+
+Add an ordered response-processor pipeline to `ModelConfig`.
+
+A model can now declare `processors: ResponseProcessor[]` — an ordered pipeline
+run in declared order after `adapter.find(ids)` resolves. This makes the fetch
+lifecycle explicit and lets applications compose response work in execution
+order (migrate → mirror into another store → insert into silo) instead of
+cramming every responsibility into one processor.
+
+```ts
+"card-stack": {
+  adapter: cardStackAdapter,
+  processors: [
+    migrateCardStackResponse(),                 // mutate fetched docs in place
+    mirrorResponseDocumentsToEmber(emberStore), // side effect: hydrate another store
+    jsonApiProcessor,                           // insert into silo
+  ],
+}
+```
+
+**Ordered pipeline semantics.** Silo passes the adapter response through each
+processor in order. A processor may mutate the response, **return a replacement
+response** (handed to later processors), perform side effects, or insert
+documents. Returning `undefined` passes the current response through unchanged.
+A throw stops the pipeline (the remaining processors don't run) and fails the
+chunk with a `ProcessorError` — the same terminal behavior as a single
+`processor` throw.
+
+**Backward compatible config.** The single `processor` field still works and is
+normalized to a one-element pipeline, so `{ adapter }`,
+`{ adapter, processor: defaultProcessor }`, and
+`{ adapter, processors: [defaultProcessor] }` are all equivalent. Setting
+**both** `processor` and `processors` on the same model is a configuration error
+and throws at store creation.
+
+**`ResponseProcessor` signature.** Its shape is now
+`(response, context) => unknown | void`, where `context` is
+`{ store, type, ids }` (previously `(raw, store, type) => void`). The bundled
+`defaultProcessor` / `jsonApiProcessor` and every config that uses them are
+unaffected; hand-written custom processors that relied on the old positional
+`(raw, store, type)` arguments should read `store` / `type` off the context
+object and can now return a replacement response. A new `ProcessorContext` type
+is exported for typing custom processors.

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -594,12 +594,10 @@ type TypeToQuery = {
 };
 
 const usersByRoleProcessor: QueryProcessor<TypeToModel, TypeToQuery, "usersByRole"> = (
-  raw,
-  store,
-  type,
-  paramsList,
+  response,
+  { store, type, paramsList },
 ) => {
-  const results = raw as Array<User[]>; // adapter returns one User[] per params
+  const results = response as Array<User[]>; // adapter returns one User[] per params
   for (let i = 0; i < paramsList.length; i++) {
     const users = results[i];
     // Normalize: insert each user into the documents cache
@@ -643,7 +641,7 @@ Plain → normalized is a local change (swap the result type, add a processor, d
 
 ### Default query processor
 
-If `QueryConfig.processor` is omitted, the library uses `defaultQueryProcessor` — assumes the adapter returns an array of results aligned 1:1 with the input params, and pairs them by position:
+If `QueryConfig.processor` (and `processors`) is omitted, the library uses `defaultQueryProcessor` — assumes the adapter returns an array of results aligned 1:1 with the input params, and pairs them by position:
 
 ```ts
 // adapter returns: [resultForParams0, resultForParams1, ...]
@@ -651,6 +649,8 @@ If `QueryConfig.processor` is omitted, the library uses `defaultQueryProcessor` 
 ```
 
 No normalization (nested entities stay inside the query result). For normalization, write a custom processor as shown above.
+
+Queries support the same **ordered pipeline** as documents — supply `processors: [...]` instead of a single `processor` to compose response steps in execution order. A query processor is `(response, context) => unknown | void`, where `context` is `{ store, type, paramsList }` (`paramsList` in place of a document processor's `ids`). The same rules apply: returning a value replaces the response for later steps, returning `undefined` passes it through, a throw stops the pipeline with a `ProcessorError`, and supplying both `processor` and `processors` throws at store creation.
 
 ### When to use which
 

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -462,7 +462,7 @@ const insert: ResponseProcessor<TypeToModel> = (response, { store, type }) => {
 };
 ```
 
-Returning a value replaces the response handed to later processors; returning `undefined` passes the current response through unchanged. If you need GraphQL, a REST envelope, or a bespoke wire format — write one. Processors are synchronous; for async normalization, do it in the adapter. If a processor throws, the remaining processors don't run and the fetch fails with a `ProcessorError` — the same terminal behavior as a single-`processor` throw.
+Returning a value replaces the response handed to later processors; returning `undefined` (or `null`) passes the current response through unchanged. If you need GraphQL, a REST envelope, or a bespoke wire format — write one. Processors are synchronous; for async normalization, do it in the adapter. If a processor throws, the remaining processors don't run and the fetch fails with a `ProcessorError` — the same terminal behavior as a single-`processor` throw.
 
 ## Queries
 

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -344,10 +344,7 @@ The Finder is internal — you never construct or import it — but it's what ma
 
 ## Processors
 
-The adapter returns whatever its fetch chain returns — typically already-parsed JSON. A processor takes that parsed response and calls `store.insertDocument(type, doc)` for every document worth caching.
-
-Processors are an **ordered response pipeline.** The adapter returns a response. Silo passes that response through each processor in order. A processor may mutate the response, return a replacement response, perform side effects, or insert documents into the store. If it returns `undefined`, the current response continues to the next processor. Most pipelines end with an insertion processor.
-
+Processors are an **ordered response pipeline.** The adapter returns a response. Silo passes that response through each processor in order. A processor may mutate the response, return a replacement response, perform side effects, or insert documents into the store. If it returns `undefined` (or `null`), the current response continues to the next processor. Most pipelines end with an insertion processor.
 Configure a single step with `processor`, or an ordered array with `processors`:
 
 ```ts

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -344,7 +344,10 @@ The Finder is internal — you never construct or import it — but it's what ma
 
 ## Processors
 
+The adapter returns whatever its fetch chain returns — typically already-parsed JSON. A processor takes that parsed response and calls `store.insertDocument(type, doc)` for every document worth caching.
+
 Processors are an **ordered response pipeline.** The adapter returns a response. Silo passes that response through each processor in order. A processor may mutate the response, return a replacement response, perform side effects, or insert documents into the store. If it returns `undefined` (or `null`), the current response continues to the next processor. Most pipelines end with an insertion processor.
+
 Configure a single step with `processor`, or an ordered array with `processors`:
 
 ```ts
@@ -459,7 +462,7 @@ const insert: ResponseProcessor<TypeToModel> = (response, { store, type }) => {
 };
 ```
 
-Returning a value replaces the response handed to later processors; returning `undefined` (or `null`) passes the current response through unchanged. If you need GraphQL, a REST envelope, or a bespoke wire format — write one. Processors are synchronous; for async normalization, do it in the adapter. If a processor throws, the remaining processors don't run and the fetch fails with a `ProcessorError` — the same terminal behavior as a single-`processor` throw.
+Returning a value replaces the response handed to later processors; returning `undefined` (or `null`) passes the current response through unchanged. (Pass-through uses `??`, so `null` can't be used to replace the response.) If you need GraphQL, a REST envelope, or a bespoke wire format — write one. Processors are synchronous; for async normalization, do it in the adapter. If a processor throws, the remaining processors don't run and the fetch fails with a `ProcessorError` — the same terminal behavior as a single-`processor` throw.
 
 ## Queries
 

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -204,7 +204,7 @@ const store = createDocumentStore<TypeToModel>({
 
 Each model (and query) can also take:
 
-- `processor` to normalize the adapter's raw response — see [Processors](#processors) below. Omit it and the default processor assumes the adapter returns a doc or an array of docs.
+- `processor` (a single step) or `processors` (an ordered pipeline) to turn the adapter's response into store inserts — see [Processors](#processors) below. Omit both and the default processor assumes the adapter returns a doc or an array of docs. Supplying **both** is a configuration error and throws at store creation.
 - `retry` — an Effect `Schedule` applied to the adapter Effect on a **retryable** `AdapterError` (e.g. `Schedule.exponential("100 millis").pipe(Schedule.compose(Schedule.recurs(3)))`). An Effect adapter can mark an `AdapterError` `retryable: false` (a deterministic 4xx, say) to fail fast instead of looping.
 - `retryable` — a `(error: AdapterError) => boolean` classifier, for **Promise-first** adapters that reject (and so can't set the error's own `retryable` flag). Inspect `error.cause` to veto retries: `(e) => !(e.cause instanceof Response) || e.cause.status >= 500`. An error that opts out via its own `retryable: false` is a hard veto regardless. A veto is **stamped onto the error** (`retryable: false`), so what lands on `handle.error` / `lastError` and the `onError` sink always agrees with the engine's actual decision; the classifier runs exactly once per failed attempt.
 - `timeout` — a `Duration` bounding a **single attempt**; on expiry that attempt fails with an `AdapterError`.
@@ -344,7 +344,28 @@ The Finder is internal — you never construct or import it — but it's what ma
 
 ## Processors
 
-The adapter returns whatever its fetch chain returns — typically already-parsed JSON. The processor takes that parsed response and calls `store.insertDocument(type, doc)` for every document worth caching.
+The adapter returns whatever its fetch chain returns — typically already-parsed JSON. A processor takes that parsed response and calls `store.insertDocument(type, doc)` for every document worth caching.
+
+Processors are an **ordered response pipeline.** The adapter returns a response. Silo passes that response through each processor in order. A processor may mutate the response, return a replacement response, perform side effects, or insert documents into the store. If it returns `undefined`, the current response continues to the next processor. Most pipelines end with an insertion processor.
+
+Configure a single step with `processor`, or an ordered array with `processors`:
+
+```ts
+createDocumentStore<TypeToModel>({
+  models: {
+    "card-stack": {
+      adapter: cardStackAdapter,
+      processors: [
+        migrateCardStackResponse(), // mutate fetched docs in place
+        mirrorResponseDocumentsToEmber(emberStore), // side effect: hydrate another store
+        jsonApiProcessor, // insert into silo
+      ],
+    },
+  },
+});
+```
+
+That reads in execution order: fetch card stacks → migrate the response docs → mirror them into the other store → insert them into silo. `processor` and `processors` are mutually exclusive — supplying both throws at store creation. `{ adapter }`, `{ adapter, processor: defaultProcessor }`, and `{ adapter, processors: [defaultProcessor] }` are all equivalent.
 
 Processors are **keyed by envelope shape, not by model.** One processor normally serves many adapters: every REST endpoint that returns `{id, ...}` or `[{id, ...}, ...]` shares `defaultProcessor`; every JSON-API endpoint in your app shares `jsonApiProcessor`; a custom `graphqlProcessor` would serve every GraphQL-returning adapter. The per-model `processor` field isn't one-per-adapter — it's "which envelope parser does this adapter's response need."
 
@@ -423,7 +444,25 @@ const cards = useHasMany(planbook.value ?? null, "cards");
 
 ### Custom
 
-Any function matching `(raw, store, type) => void` works. If you need GraphQL, a REST envelope, or a bespoke wire format — write one. Processors are synchronous; for async normalization, do it in the adapter.
+A processor is any function matching `(response, context) => unknown | void`, where `context` is `{ store, type, ids }`:
+
+```ts
+import { type ResponseProcessor } from "@supergrain/silo";
+
+// Transform: return a replacement response for the next step.
+const normalize: ResponseProcessor<TypeToModel> = (response) => {
+  for (const doc of responseDocs(response)) migrateInPlace(doc);
+  return response;
+};
+
+// Insert: the terminal step. Returns nothing — silo reads each requested
+// (type, id) from memory afterward to settle the handle.
+const insert: ResponseProcessor<TypeToModel> = (response, { store, type }) => {
+  for (const doc of responseDocs(response)) store.insertDocument(type, doc);
+};
+```
+
+Returning a value replaces the response handed to later processors; returning `undefined` passes the current response through unchanged. If you need GraphQL, a REST envelope, or a bespoke wire format — write one. Processors are synchronous; for async normalization, do it in the adapter. If a processor throws, the remaining processors don't run and the fetch fails with a `ProcessorError` — the same terminal behavior as a single-`processor` throw.
 
 ## Queries
 

--- a/packages/silo/src/finder.ts
+++ b/packages/silo/src/finder.ts
@@ -1,4 +1,4 @@
-import type { QueryConfig, QueryProcessor, QueryTypes } from "./queries";
+import type { QueryConfig, QueryProcessor, QueryProcessorContext, QueryTypes } from "./queries";
 import type {
   DocumentStore,
   DocumentStoreConfig,
@@ -77,26 +77,43 @@ interface BisectedRerun {
 }
 
 /**
- * Normalize a model's processor config into an ordered pipeline.
- *
+ * Normalize a `{ processor?, processors? }` config into an ordered pipeline —
+ * the spec's `config.processors ?? [config.processor ?? defaultProcessor]`, so
  * `{ adapter }`, `{ processor }`, and `{ processors }` all collapse to one
- * array here — the spec's `config.processors ?? [config.processor ??
- * defaultProcessor]`. Setting **both** `processor` and `processors` is an
- * ambiguous config and throws (the Finder constructor calls this for every
- * model so the throw lands at store creation, not on first fetch). An explicit
- * empty `processors: []` is honored as "run nothing".
+ * array. Setting **both** `processor` and `processors` is an ambiguous config
+ * and throws; the Finder constructor calls this for every model and query so
+ * the throw lands at store creation, not on first fetch. An explicit empty
+ * `processors: []` is honored as "run nothing". Shared by both surfaces — the
+ * document and query pipelines differ only in their processor type and default.
  */
+function resolvePipeline<P>(
+  label: string,
+  config: { processor?: P; processors?: ReadonlyArray<P> },
+  fallback: P,
+): ReadonlyArray<P> {
+  if (config.processor !== undefined && config.processors !== undefined) {
+    throw new Error(
+      `@supergrain/silo: ${label} sets both \`processor\` and \`processors\` — supply one or the other`,
+    );
+  }
+  return config.processors ?? [config.processor ?? fallback];
+}
+
 function resolveProcessors<M extends DocumentTypes>(
   type: string,
   modelConfig: ModelConfig<M>,
 ): ReadonlyArray<ResponseProcessor<M>> {
-  if (modelConfig.processor !== undefined && modelConfig.processors !== undefined) {
-    throw new Error(
-      `@supergrain/silo: model "${type}" sets both \`processor\` and \`processors\` — supply one or the other`,
-    );
-  }
-  return (
-    modelConfig.processors ?? [modelConfig.processor ?? (defaultProcessor as ResponseProcessor<M>)]
+  return resolvePipeline(`model "${type}"`, modelConfig, defaultProcessor as ResponseProcessor<M>);
+}
+
+function resolveQueryProcessors<M extends DocumentTypes, Q extends QueryTypes>(
+  type: string,
+  queryConfig: QueryConfig<M, Q, keyof Q & string>,
+): ReadonlyArray<QueryProcessor<M, Q, keyof Q & string>> {
+  return resolvePipeline(
+    `query "${type}"`,
+    queryConfig,
+    defaultQueryProcessor as unknown as QueryProcessor<M, Q, keyof Q & string>,
   );
 }
 
@@ -136,13 +153,20 @@ export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<strin
     }
     this.permits =
       typeof maxConcurrency === "number" ? Effect.unsafeMakeSemaphore(maxConcurrency) : undefined;
-    // Validate processor config eagerly: a model that sets both `processor`
-    // and `processors` is ambiguous and should fail loudly at store creation,
-    // not silently on the first fetch of that model.
+    // Validate processor config eagerly: a model or query that sets both
+    // `processor` and `processors` is ambiguous and should fail loudly at store
+    // creation, not silently on the first fetch of that type.
     for (const [type, modelConfig] of Object.entries(config.models) as Array<
       [string, ModelConfig<M>]
     >) {
       resolveProcessors(type, modelConfig);
+    }
+    if (config.queries) {
+      for (const [type, queryConfig] of Object.entries(config.queries) as Array<
+        [string, QueryConfig<M, Q, keyof Q & string>]
+      >) {
+        resolveQueryProcessors(type, queryConfig);
+      }
     }
   }
 
@@ -442,9 +466,7 @@ export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<strin
       throw new Error(`@supergrain/silo: no query "${type}" is configured`);
     }
 
-    const processor: QueryProcessor<M, Q, keyof Q & string> =
-      queryConfig.processor ??
-      (defaultQueryProcessor as unknown as QueryProcessor<M, Q, keyof Q & string>);
+    const processors = resolveQueryProcessors(type, queryConfig);
     const paramsList = chunk.map((e) => e.params);
 
     return this.drainChunk({
@@ -457,13 +479,22 @@ export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<strin
       deadlineAt: bisected?.deadlineAt,
       // oxlint-disable-next-line no-array-method-this-argument -- QueryAdapter#find, not Array#find
       invoke: (adapterCtx) => queryConfig.adapter.find(paramsList, adapterCtx),
-      process: (raw) =>
-        processor(
-          raw,
-          this.store,
-          type as keyof Q & string,
-          paramsList as ReadonlyArray<Q[keyof Q & string]["params"]>,
-        ),
+      // Ordered response pipeline, mirroring the document surface: feed the
+      // adapter response through each query processor in turn. `?? response` is
+      // the pass-through; a throw stops the pipeline and becomes a
+      // ProcessorError. The context carries `paramsList` so a processor can
+      // pair each result with the params that produced it.
+      process: (raw) => {
+        const context: QueryProcessorContext<M, Q, keyof Q & string> = {
+          store: this.store,
+          type: type as keyof Q & string,
+          paramsList: paramsList as ReadonlyArray<Q[keyof Q & string]["params"]>,
+        };
+        let response: unknown = raw;
+        for (const processor of processors) {
+          response = processor(response, context) ?? response;
+        }
+      },
       rerun: (half, deadlineAt) => this.drainQueryChunk(type, half, { deadlineAt }),
     });
   }

--- a/packages/silo/src/finder.ts
+++ b/packages/silo/src/finder.ts
@@ -5,6 +5,7 @@ import type {
   DocumentTypes,
   InternalState,
   ModelConfig,
+  ProcessorContext,
   ResponseProcessor,
 } from "./store";
 
@@ -75,6 +76,30 @@ interface BisectedRerun {
   readonly deadlineAt: number | undefined;
 }
 
+/**
+ * Normalize a model's processor config into an ordered pipeline.
+ *
+ * `{ adapter }`, `{ processor }`, and `{ processors }` all collapse to one
+ * array here — the spec's `config.processors ?? [config.processor ??
+ * defaultProcessor]`. Setting **both** `processor` and `processors` is an
+ * ambiguous config and throws (the Finder constructor calls this for every
+ * model so the throw lands at store creation, not on first fetch). An explicit
+ * empty `processors: []` is honored as "run nothing".
+ */
+function resolveProcessors<M extends DocumentTypes>(
+  type: string,
+  modelConfig: ModelConfig<M>,
+): ReadonlyArray<ResponseProcessor<M>> {
+  if (modelConfig.processor !== undefined && modelConfig.processors !== undefined) {
+    throw new Error(
+      `@supergrain/silo: model "${type}" sets both \`processor\` and \`processors\` — supply one or the other`,
+    );
+  }
+  return (
+    modelConfig.processors ?? [modelConfig.processor ?? (defaultProcessor as ResponseProcessor<M>)]
+  );
+}
+
 export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<string, never>> {
   private config: DocumentStoreConfig<M, Q>;
   private batchWindowMs: number;
@@ -111,6 +136,14 @@ export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<strin
     }
     this.permits =
       typeof maxConcurrency === "number" ? Effect.unsafeMakeSemaphore(maxConcurrency) : undefined;
+    // Validate processor config eagerly: a model that sets both `processor`
+    // and `processors` is ambiguous and should fail loudly at store creation,
+    // not silently on the first fetch of that model.
+    for (const [type, modelConfig] of Object.entries(config.models) as Array<
+      [string, ModelConfig<M>]
+    >) {
+      resolveProcessors(type, modelConfig);
+    }
   }
 
   attach(store: DocumentStore<M, Q>): void {
@@ -362,8 +395,7 @@ export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<strin
     if (!modelConfig) {
       throw new Error(`@supergrain/silo: no model "${type}" is configured`);
     }
-    const processor: ResponseProcessor<M> =
-      modelConfig.processor ?? (defaultProcessor as ResponseProcessor<M>);
+    const processors = resolveProcessors(type, modelConfig);
 
     return this.drainChunk({
       type,
@@ -375,7 +407,23 @@ export class Finder<M extends DocumentTypes, Q extends QueryTypes = Record<strin
       deadlineAt: bisected?.deadlineAt,
       // oxlint-disable-next-line no-array-method-this-argument -- DocumentAdapter#find, not Array#find
       invoke: (adapterCtx) => modelConfig.adapter.find(ids, adapterCtx),
-      process: (raw) => processor(raw, this.store as DocumentStore<M>, type as keyof M & string),
+      // Ordered response pipeline: feed the adapter response through each
+      // processor in turn. A processor may mutate it, return a replacement, or
+      // perform side effects (typically `insertDocument`). `?? response` is the
+      // pass-through — returning undefined/null leaves the current response for
+      // the next step. A throw stops the pipeline (the remaining processors do
+      // not run) and `runProcessor` turns it into a `ProcessorError`.
+      process: (raw) => {
+        const context: ProcessorContext<M> = {
+          store: this.store as DocumentStore<M>,
+          type: type as keyof M & string,
+          ids,
+        };
+        let response: unknown = raw;
+        for (const processor of processors) {
+          response = processor(response, context) ?? response;
+        }
+      },
       rerun: (half, deadlineAt) => this.drainDocumentChunk(type, half, { deadlineAt }),
     });
   }

--- a/packages/silo/src/index.ts
+++ b/packages/silo/src/index.ts
@@ -16,6 +16,7 @@ export type {
   DocumentTypes,
   HandleStatus,
   ModelConfig,
+  ProcessorContext,
   RegisteredTypes,
   ResponseProcessor,
   StoreAdapterRunOptions,

--- a/packages/silo/src/index.ts
+++ b/packages/silo/src/index.ts
@@ -48,6 +48,7 @@ export type {
   QueryConfig,
   QueryHandle,
   QueryProcessor,
+  QueryProcessorContext,
   QueryTypes,
   RegisteredQueries,
 } from "./queries";

--- a/packages/silo/src/processors/index.ts
+++ b/packages/silo/src/processors/index.ts
@@ -1,5 +1,5 @@
-import type { QueryTypes } from "../queries";
-import type { DocumentStore, DocumentTypes, ProcessorContext } from "../store";
+import type { QueryProcessorContext, QueryTypes } from "../queries";
+import type { DocumentTypes, ProcessorContext } from "../store";
 
 // =============================================================================
 // defaultProcessor — insert by (type, id), no envelope
@@ -67,14 +67,11 @@ export function defaultProcessor<M extends DocumentTypes>(
  * sideloads), write a custom processor — this default only handles the
  * position-paired case.
  */
-// oxlint-disable-next-line max-params
 export function defaultQueryProcessor<M extends DocumentTypes, Q extends QueryTypes>(
-  raw: unknown,
-  store: DocumentStore<M, Q>,
-  type: keyof Q & string,
-  paramsList: ReadonlyArray<unknown>,
+  response: unknown,
+  { store, type, paramsList }: QueryProcessorContext<M, Q, keyof Q & string>,
 ): void {
-  const results = raw as ReadonlyArray<unknown>;
+  const results = response as ReadonlyArray<unknown>;
   for (let i = 0; i < paramsList.length; i++) {
     store.insertQueryResult(
       type,

--- a/packages/silo/src/processors/index.ts
+++ b/packages/silo/src/processors/index.ts
@@ -1,5 +1,5 @@
 import type { QueryTypes } from "../queries";
-import type { DocumentStore, DocumentTypes } from "../store";
+import type { DocumentStore, DocumentTypes, ProcessorContext } from "../store";
 
 // =============================================================================
 // defaultProcessor — insert by (type, id), no envelope
@@ -30,11 +30,10 @@ import type { DocumentStore, DocumentTypes } from "../store";
  * implementation of the JSON-API envelope.
  */
 export function defaultProcessor<M extends DocumentTypes>(
-  raw: unknown,
-  store: DocumentStore<M>,
-  type: keyof M & string,
+  response: unknown,
+  { store, type }: ProcessorContext<M>,
 ): void {
-  const docs = Array.isArray(raw) ? raw : [raw];
+  const docs = Array.isArray(response) ? response : [response];
   for (const doc of docs) store.insertDocument(type, doc as M[keyof M & string]);
 }
 

--- a/packages/silo/src/processors/json-api.ts
+++ b/packages/silo/src/processors/json-api.ts
@@ -1,4 +1,4 @@
-import type { DocumentStore, DocumentTypes } from "../store";
+import type { DocumentTypes, ProcessorContext } from "../store";
 
 // =============================================================================
 // JSON-API types
@@ -111,11 +111,10 @@ interface JsonApiEnvelope {
  * ```
  */
 export function jsonApiProcessor<M extends DocumentTypes>(
-  raw: unknown,
-  store: DocumentStore<M>,
-  _type: keyof M & string,
+  response: unknown,
+  { store }: ProcessorContext<M>,
 ): void {
-  const envelope = raw as JsonApiEnvelope;
+  const envelope = response as JsonApiEnvelope;
   const data = envelope.data ?? [];
   const included = envelope.included ?? [];
   for (const doc of data) {

--- a/packages/silo/src/queries.ts
+++ b/packages/silo/src/queries.ts
@@ -82,55 +82,79 @@ export interface QueryAdapter<Params> {
 }
 
 // =============================================================================
-// QueryProcessor — raw response → inserts
+// QueryProcessor — ordered response pipeline step (query surface)
 // =============================================================================
 
 /**
- * Transforms a raw query-adapter response into store inserts.
+ * Context handed to every {@link QueryProcessor} in a query's pipeline: the
+ * `store`, the `type` the caller passed to `findQuery(type, params)`, and the
+ * chunk's input `paramsList` (so a result can be associated with the params
+ * that produced it). Mirrors {@link import("./store").ProcessorContext} on the
+ * document surface, with `paramsList` in place of `ids`.
+ */
+export interface QueryProcessorContext<
+  M extends DocumentTypes,
+  Q extends QueryTypes,
+  Type extends keyof Q & string,
+> {
+  /** The store — insert results with `insertQueryResult`, docs with `insertDocument`. */
+  readonly store: DocumentStore<M, Q>;
+  /** The type the caller passed to `findQuery(type, params)` for this chunk. */
+  readonly type: Type;
+  /** The batch's input params, aligned to the adapter's positional results. */
+  readonly paramsList: ReadonlyArray<Q[Type]["params"]>;
+}
+
+/**
+ * One step in a query's ordered response pipeline.
  *
- * Unlike `ResponseProcessor` (which operates purely on documents), a query
- * processor receives the batch's input params (`paramsList`) as a fourth
- * argument so it can associate each result with the params that produced
- * it. The processor calls `store.insertQueryResult(type, params, result)`
- * for every result it wants cached.
+ * Like {@link import("./store").ResponseProcessor} on the document surface, but
+ * its context carries the batch's input `paramsList` (instead of `ids`) so it
+ * can associate each result with the params that produced it. Silo passes the
+ * adapter response through each processor in order. A processor may **mutate**
+ * the response, **return a replacement** response, perform **side effects**, or
+ * **insert results** via `store.insertQueryResult(type, params, result)`. If it
+ * returns `undefined` (or `null`), the current response continues unchanged to
+ * the next processor. Most pipelines end with an insertion processor.
  *
  * A query processor can also call `store.insertDocument(...)` to normalize
- * nested entities into the documents cache — this is how queries populate
- * the shared memory so `useDocument` reads benefit from results fetched
- * via queries. Example: a `usersByRole` query inserts each returned user
- * as a document, then stores the id-list as the query result.
+ * nested entities into the documents cache — this is how queries populate the
+ * shared memory so `useDocument` reads benefit from results fetched via
+ * queries. Example: a `usersByRole` query inserts each returned user as a
+ * document, then stores the id-list as the query result.
  *
  * Contract:
  * - Synchronous. For async normalization, do it in the adapter before it returns.
- * - Must call `store.insertQueryResult(...)` for every result it wants
- *   cached — the library does NOT auto-insert anything from a processor.
- * - If the processor throws, all deferreds waiting on this chunk reject
- *   with the thrown error.
+ * - The terminal step must call `store.insertQueryResult(...)` for every result
+ *   it wants cached — the library does NOT auto-insert anything from a processor.
+ * - If it throws, the remaining processors do not run and all deferreds waiting
+ *   on this chunk reject with the thrown error.
  */
 export type QueryProcessor<
   M extends DocumentTypes,
   Q extends QueryTypes,
   Type extends keyof Q & string,
-> = (
-  raw: unknown,
-  store: DocumentStore<M, Q>,
-  type: Type,
-  paramsList: ReadonlyArray<Q[Type]["params"]>,
-) => void;
+> = (response: unknown, context: QueryProcessorContext<M, Q, Type>) => unknown | void;
 
 // =============================================================================
 // Per-query config
 // =============================================================================
 
 /**
- * Per-query wiring: the adapter that talks to the API and the optional
- * processor that normalizes its response.
+ * Per-query wiring: the adapter that talks to the API and the response
+ * processor(s) that turn its response into store inserts.
  *
- * If `processor` is omitted, the library uses `defaultQueryProcessor` —
- * assumes the adapter returns an array of results aligned 1:1 with the
- * input params, and pairs them by position. For envelope formats or
- * normalizing processors (inserting nested documents), supply a custom
- * `QueryProcessor`.
+ * Responses run through an **ordered pipeline**, configured either way:
+ * - `processor` — a single {@link QueryProcessor} (normalized to a one-element
+ *   pipeline).
+ * - `processors` — an ordered array of {@link QueryProcessor}s, run in declared
+ *   order.
+ *
+ * Supply at most one; setting **both** throws at store creation. If neither is
+ * supplied, the library uses `defaultQueryProcessor` — assumes the adapter
+ * returns an array of results aligned 1:1 with the input params, and pairs them
+ * by position. For envelope formats or normalizing processors (inserting nested
+ * documents), supply your own.
  *
  * The inherited resilience knobs ({@link ResilienceOptions}: `retry` /
  * `timeout` / `deadline` / `retryable` / `isolateFailures`) override the
@@ -143,7 +167,13 @@ export interface QueryConfig<
   Type extends keyof Q & string,
 > extends ResilienceOptions {
   adapter: QueryAdapter<Q[Type]["params"]>;
+  /** A single query processor. Mutually exclusive with `processors`. */
   processor?: QueryProcessor<M, Q, Type>;
+  /**
+   * An ordered query-response pipeline, run in declared order. Mutually
+   * exclusive with `processor`.
+   */
+  processors?: ReadonlyArray<QueryProcessor<M, Q, Type>>;
 }
 
 // =============================================================================

--- a/packages/silo/src/queries.ts
+++ b/packages/silo/src/queries.ts
@@ -127,8 +127,8 @@ export interface QueryProcessorContext<
  * - Synchronous. For async normalization, do it in the adapter before it returns.
  * - The terminal step must call `store.insertQueryResult(...)` for every result
  *   it wants cached — the library does NOT auto-insert anything from a processor.
- * - If it throws, the remaining processors do not run and all deferreds waiting
- *   on this chunk reject with the thrown error.
+ * - If it throws, the remaining processors do not run and every deferred on the
+ *   chunk fails with a `ProcessorError` (its `cause` is the thrown error).
  */
 export type QueryProcessor<
   M extends DocumentTypes,

--- a/packages/silo/src/store.ts
+++ b/packages/silo/src/store.ts
@@ -227,7 +227,7 @@ export interface ProcessorContext<M extends DocumentTypes> {
   /** The type the caller passed to `find(type, id)` for this chunk. */
   readonly type: keyof M & string;
   /** The document ids this chunk fetched. */
-  readonly ids: Array<string>;
+  readonly ids: ReadonlyArray<string>;
 }
 
 /**

--- a/packages/silo/src/store.ts
+++ b/packages/silo/src/store.ts
@@ -175,7 +175,7 @@ export type DocumentHandle<T, E = SiloError> =
  * `AdapterError` automatically. Power users can **return an `Effect`** instead
  * to control the failure channel, compose their own retries, or manage
  * resources; it's used as-is. The library doesn't inspect the raw value — only
- * the paired `ResponseProcessor` does.
+ * the model's configured `ResponseProcessor`(s) do.
  *
  * Contract:
  * - `find` receives a chunk of at most `DocumentStoreConfig.batchSize` ids,
@@ -213,42 +213,92 @@ export interface DocumentAdapter {
 }
 
 // =============================================================================
-// ResponseProcessor — raw response → inserts
+// ResponseProcessor — ordered response pipeline step
 // =============================================================================
 
 /**
- * Transforms a raw adapter response into store inserts. Calls
- * `store.insertDocument(type, doc)` for every document it wants cached (primary
- * + sideloaded). Returns nothing; the library looks up each requested
- * `(type, id)` via `store.findInMemory` afterward to settle the handle.
+ * Context handed to every {@link ResponseProcessor} in a model's pipeline: the
+ * `store` (to read cached docs and insert new ones), the `type` the caller
+ * passed to `find(type, id)`, and the chunk's requested `ids`.
+ */
+export interface ProcessorContext<M extends DocumentTypes> {
+  /** The store — read with `findInMemory`, write with `insertDocument`. */
+  readonly store: DocumentStore<M>;
+  /** The type the caller passed to `find(type, id)` for this chunk. */
+  readonly type: keyof M & string;
+  /** The document ids this chunk fetched. */
+  readonly ids: Array<string>;
+}
+
+/**
+ * One step in a model's ordered response pipeline.
+ *
+ * The adapter returns a response. Silo passes that response through each
+ * processor in order. A processor may **mutate** the response, **return a
+ * replacement** response, perform **side effects**, or **insert documents**
+ * into the store. If it returns `undefined` (or `null`), the current response
+ * continues unchanged to the next processor. Most pipelines end with an
+ * insertion processor that calls `store.insertDocument(type, doc)` for every
+ * document worth caching; the library then looks up each requested
+ * `(type, id)` via `store.findInMemory` to settle the handle.
  *
  * Contract:
  * - Synchronous. For async normalization, do it in the adapter Effect.
- * - If it throws, every deferred on the chunk fails with a `ProcessorError`.
+ * - If it throws, the remaining processors do not run and every deferred on
+ *   the chunk fails with a `ProcessorError`.
+ *
+ * @example
+ * ```ts
+ * const normalize: ResponseProcessor<M> = (response) => {
+ *   for (const doc of responseDocs(response)) migrateInPlace(doc);
+ *   return response;
+ * };
+ *
+ * const insert: ResponseProcessor<M> = (response, { store, type }) => {
+ *   for (const doc of responseDocs(response)) store.insertDocument(type, doc);
+ * };
+ * ```
  */
 export type ResponseProcessor<M extends DocumentTypes> = (
-  raw: unknown,
-  store: DocumentStore<M>,
-  type: keyof M & string,
-) => void;
+  response: unknown,
+  context: ProcessorContext<M>,
+) => unknown | void;
 
 // =============================================================================
 // Per-model config
 // =============================================================================
 
 /**
- * Per-model wiring: the adapter that talks to the API, an optional processor
- * that normalizes its response, and optional Effect-native resilience.
+ * Per-model wiring: the adapter that talks to the API, the response
+ * processor(s) that turn its response into store inserts, and optional
+ * Effect-native resilience.
  *
- * If `processor` is omitted, the library uses `defaultProcessor`. The inherited
- * resilience knobs ({@link ResilienceOptions}: `retry` / `timeout` /
- * `deadline` / `retryable` / `isolateFailures`) override the store-wide
- * defaults for this model — resolution precedence is per-model → store-wide →
- * built-in `defaultRetry`.
+ * Responses run through an **ordered pipeline**. Configure it either way:
+ * - `processor` — a single {@link ResponseProcessor} (normalized to a
+ *   one-element pipeline).
+ * - `processors` — an ordered array of {@link ResponseProcessor}s, run in
+ *   declared order.
+ *
+ * Supply at most one. Setting **both** is a configuration error and throws at
+ * store creation — the intent is ambiguous. If neither is supplied, the
+ * library uses `defaultProcessor` (so `{ adapter }`,
+ * `{ adapter, processor: defaultProcessor }`, and
+ * `{ adapter, processors: [defaultProcessor] }` are equivalent).
+ *
+ * The inherited resilience knobs ({@link ResilienceOptions}: `retry` /
+ * `timeout` / `deadline` / `retryable` / `isolateFailures`) override the
+ * store-wide defaults for this model — resolution precedence is per-model →
+ * store-wide → built-in `defaultRetry`.
  */
 export interface ModelConfig<M extends DocumentTypes> extends ResilienceOptions {
   adapter: DocumentAdapter;
+  /** A single response processor. Mutually exclusive with `processors`. */
   processor?: ResponseProcessor<M>;
+  /**
+   * An ordered response pipeline, run in declared order. Mutually exclusive
+   * with `processor`.
+   */
+  processors?: ReadonlyArray<ResponseProcessor<M>>;
 }
 
 // =============================================================================
@@ -270,7 +320,7 @@ export interface DocumentStoreConfig<
   M extends DocumentTypes,
   Q extends QueryTypes = Record<string, never>,
 > extends ResilienceOptions {
-  /** Per-type adapter + optional processor wiring for documents. */
+  /** Per-type adapter + optional response-processor pipeline for documents. */
   models: { [K in keyof M]: ModelConfig<M> };
   /** Per-type adapter + optional processor wiring for queries. Optional. */
   queries?: { [K in keyof Q & string]: QueryConfig<M, Q, K> };

--- a/packages/silo/src/store.ts
+++ b/packages/silo/src/store.ts
@@ -245,7 +245,7 @@ export interface ProcessorContext<M extends DocumentTypes> {
  * Contract:
  * - Synchronous. For async normalization, do it in the adapter Effect.
  * - If it throws, the remaining processors do not run and every deferred on
- *   the chunk fails with a `ProcessorError`.
+ *   the chunk fails with a `ProcessorError` (its `cause` is the thrown error).
  *
  * @example
  * ```ts

--- a/packages/silo/tests/finder.test.ts
+++ b/packages/silo/tests/finder.test.ts
@@ -11,6 +11,7 @@ import {
   type QueryAdapter,
 } from "../src";
 import { Finder } from "../src/finder";
+import { defaultProcessor } from "../src/processors";
 import { type InternalHandle, makeIdleHandle } from "../src/transitions";
 import { effectFind } from "./setup/effect-find";
 import { setupFakeTimers } from "./setup/timers";
@@ -798,5 +799,229 @@ describe("adapter boundary (Promise | Effect)", () => {
     await flushBatch();
 
     expect(h.value?.name).toBe("User1");
+  });
+});
+
+// =============================================================================
+// Processor pipeline
+//
+// A model's response is fed through an ordered array of processors. Each may
+// mutate the response, return a replacement, perform a side effect, or insert
+// documents. Returning undefined/null passes the current response through
+// unchanged; a throw stops the pipeline and fails the chunk with a
+// ProcessorError — the same terminal behavior as a single `processor` throw.
+// =============================================================================
+
+type UserDoc = { id: string; name: string };
+
+/** A document adapter that returns one `{ id, name }` per requested id. */
+function userDocsFind(): DocumentAdapter["find"] {
+  return async (ids) => ids.map((id) => ({ id, name: `User${id}` }));
+}
+
+/** A terminal insertion processor: inserts each doc under the context's type. */
+const insertUserDocs = (
+  response: unknown,
+  { store, type }: { store: DocumentStore<TestTypes>; type: keyof TestTypes & string },
+): void => {
+  for (const doc of response as ReadonlyArray<UserDoc>) {
+    store.insertDocument(type, doc as TestTypes[keyof TestTypes & string]);
+  }
+};
+
+describe("processor pipeline", () => {
+  it("runs processors in declared order and hands each the requested ids", async () => {
+    const order: number[] = [];
+    let sawIds: ReadonlyArray<string> | undefined;
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: {
+          adapter: { find: userDocsFind() },
+          processors: [
+            (response, { ids }) => {
+              order.push(0);
+              sawIds = ids;
+              return response;
+            },
+            (response) => {
+              order.push(1);
+              return response;
+            },
+            (response, ctx) => {
+              order.push(2);
+              insertUserDocs(response, ctx);
+            },
+          ],
+        },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "1");
+    await flushBatch();
+
+    expect(order).toEqual([0, 1, 2]);
+    expect(sawIds).toEqual(["1"]);
+    expect(h.value?.name).toBe("User1");
+  });
+
+  it("replaces the response passed to later processors when a processor returns a value", async () => {
+    let downstream: unknown;
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: {
+          // Adapter returns an envelope; the first processor unwraps it.
+          adapter: { find: async (ids) => ({ data: ids }) },
+          processors: [
+            (response) =>
+              (response as { data: string[] }).data.map((id) => ({ id, name: `User${id}` })),
+            (response, ctx) => {
+              downstream = response;
+              insertUserDocs(response, ctx);
+            },
+          ],
+        },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "7");
+    await flushBatch();
+
+    // The second processor saw the replacement, not the raw envelope.
+    expect(downstream).toEqual([{ id: "7", name: "User7" }]);
+    expect(h.value?.name).toBe("User7");
+  });
+
+  it("passes the current response through unchanged when a processor returns undefined", async () => {
+    const seen: unknown[] = [];
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: {
+          adapter: { find: userDocsFind() },
+          processors: [
+            (response) => {
+              seen.push(response);
+              // No return → undefined → pass-through.
+            },
+            (response, ctx) => {
+              seen.push(response);
+              insertUserDocs(response, ctx);
+            },
+          ],
+        },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "1");
+    await flushBatch();
+
+    // Same reference flowed to the next step — the void return didn't replace it.
+    expect(seen[0]).toBe(seen[1]);
+    expect(h.value?.name).toBe("User1");
+  });
+
+  it("supports a side-effect-only processor before the insertion processor", async () => {
+    const mirrored: string[] = [];
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: {
+          adapter: { find: userDocsFind() },
+          processors: [
+            // Mutate the response in place.
+            (response) => {
+              for (const doc of response as ReadonlyArray<UserDoc>) {
+                doc.name = doc.name.toUpperCase();
+              }
+            },
+            // Side effect only: mirror ids elsewhere, no return, no insert.
+            (response) => {
+              for (const doc of response as ReadonlyArray<UserDoc>) mirrored.push(doc.id);
+            },
+            insertUserDocs,
+          ],
+        },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "3");
+    await flushBatch();
+
+    expect(mirrored).toEqual(["3"]);
+    expect(h.value?.name).toBe("USER3"); // in-place mutation survived to the insert
+  });
+
+  it("stops the pipeline on a thrown processor and fails the chunk with a ProcessorError", async () => {
+    const ran: string[] = [];
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: {
+          adapter: { find: userDocsFind() },
+          processors: [
+            () => {
+              ran.push("first");
+            },
+            () => {
+              ran.push("boom");
+              throw new Error("pipeline exploded");
+            },
+            (response, ctx) => {
+              ran.push("insert");
+              insertUserDocs(response, ctx);
+            },
+          ],
+        },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "1");
+    await flushBatch();
+
+    // The processor after the throw never ran.
+    expect(ran).toEqual(["first", "boom"]);
+    expect(h.error?._tag).toBe("ProcessorError");
+    const cause = (h.error as { cause?: unknown }).cause;
+    expect((cause as Error).message).toMatch(/pipeline exploded/);
+  });
+
+  it("throws at store creation when a model sets both `processor` and `processors`", () => {
+    expect(() =>
+      createDocumentStore<TestTypes>({
+        models: {
+          user: {
+            adapter: makeUserAdapter(),
+            processor: insertUserDocs,
+            processors: [insertUserDocs],
+          },
+          post: { adapter: makePostAdapter() },
+        },
+      }),
+    ).toThrow(/both `processor` and `processors`/);
+  });
+
+  it("treats `processors: [defaultProcessor]` the same as the implicit default", async () => {
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: {
+          adapter: { find: userDocsFind() },
+          processors: [defaultProcessor],
+        },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "5");
+    await flushBatch();
+
+    expect(h.value).toEqual({ id: "5", name: "User5" });
   });
 });

--- a/packages/silo/tests/finder.test.ts
+++ b/packages/silo/tests/finder.test.ts
@@ -1024,4 +1024,22 @@ describe("processor pipeline", () => {
 
     expect(h.value).toEqual({ id: "5", name: "User5" });
   });
+
+  it("runs nothing for an explicit empty `processors: []` — handle settles to NotFoundError", async () => {
+    // `processors ?? [processor ?? default]` honors an explicit `[]` as "run
+    // nothing": no processor inserts, so the requested id is never found.
+    const store = createDocumentStore<TestTypes>({
+      models: {
+        user: { adapter: { find: userDocsFind() }, processors: [] },
+        post: { adapter: makePostAdapter() },
+      },
+      retry: Schedule.recurs(0),
+    });
+
+    const h = store.find("user", "1");
+    await flushBatch();
+
+    expect(h.value).toBeUndefined();
+    expect(h.error?._tag).toBe("NotFoundError");
+  });
 });

--- a/packages/silo/tests/processors/index.test.ts
+++ b/packages/silo/tests/processors/index.test.ts
@@ -75,7 +75,7 @@ describe("defaultProcessor", () => {
     const { store, inserts } = makeFakeStore();
     const user = makeUser("1");
 
-    defaultProcessor(user, store, "user");
+    defaultProcessor(user, { store, type: "user", ids: ["1"] });
 
     expect(inserts).toEqual([{ type: "user", doc: user }]);
   });
@@ -84,7 +84,7 @@ describe("defaultProcessor", () => {
     const { store, inserts } = makeFakeStore();
     const users = [makeUser("1"), makeUser("2"), makeUser("3")];
 
-    defaultProcessor(users, store, "user");
+    defaultProcessor(users, { store, type: "user", ids: ["1", "2", "3"] });
 
     expect(inserts).toEqual([
       { type: "user", doc: users[0] },
@@ -101,14 +101,14 @@ describe("defaultProcessor", () => {
     const user = makeUser("1");
     expect("type" in user).toBe(false);
 
-    defaultProcessor(user, store, "user");
+    defaultProcessor(user, { store, type: "user", ids: ["1"] });
 
     expect(inserts).toEqual([{ type: "user", doc: user }]);
   });
 
   it("returns void — the library looks up resolved docs from memory afterwards", () => {
     const { store } = makeFakeStore();
-    const result = defaultProcessor(makeUser("1"), store, "user");
+    const result = defaultProcessor(makeUser("1"), { store, type: "user", ids: ["1"] });
     expect(result).toBeUndefined();
   });
 
@@ -123,7 +123,7 @@ describe("defaultProcessor", () => {
 
     // Everything goes in under "user" because that's the arg — the second
     // item is structurally compatible (it has an id) and gets inserted.
-    defaultProcessor(mixed, store, "user");
+    defaultProcessor(mixed, { store, type: "user", ids: ["1", "10"] });
 
     expect(inserts).toHaveLength(2);
     expect(inserts[0].type).toBe("user");
@@ -132,7 +132,7 @@ describe("defaultProcessor", () => {
 
   it("handles an empty array response without inserting anything", () => {
     const { store, inserts } = makeFakeStore();
-    expect(() => defaultProcessor([], store, "user")).not.toThrow();
+    expect(() => defaultProcessor([], { store, type: "user", ids: [] })).not.toThrow();
     expect(inserts).toEqual([]);
   });
 });

--- a/packages/silo/tests/processors/index.test.ts
+++ b/packages/silo/tests/processors/index.test.ts
@@ -157,7 +157,7 @@ describe("defaultQueryProcessor", () => {
       makeDashboard({ totalActiveUsers: 80 }),
     ];
 
-    defaultQueryProcessor(results, store, "dashboard", paramsList);
+    defaultQueryProcessor(results, { store, type: "dashboard", paramsList });
 
     expect(inserts).toEqual([
       { type: "dashboard", params: paramsList[0], result: results[0] },
@@ -173,7 +173,7 @@ describe("defaultQueryProcessor", () => {
     const params: DashboardParams = { workspaceId: 7, filters: { active: true } };
     const result = makeDashboard({ totalActiveUsers: 70 });
 
-    defaultQueryProcessor([result], store, "dashboard", [params]);
+    defaultQueryProcessor([result], { store, type: "dashboard", paramsList: [params] });
 
     expect(inserts).toHaveLength(1);
     expect(inserts[0].params).toBe(params);
@@ -188,22 +188,26 @@ describe("defaultQueryProcessor", () => {
     ];
     const results = [makeDashboard(), makeDashboard()];
 
-    defaultQueryProcessor(results, store, "dashboard", paramsList);
+    defaultQueryProcessor(results, { store, type: "dashboard", paramsList });
 
     expect(inserts.every((i) => i.type === "dashboard")).toBe(true);
   });
 
   it("returns void — the library looks up resolved query results from memory afterwards", () => {
     const { store } = makeFakeQueryStore();
-    const result = defaultQueryProcessor([makeDashboard()], store, "dashboard", [
-      { workspaceId: 7, filters: { active: true } },
-    ]);
+    const result = defaultQueryProcessor([makeDashboard()], {
+      store,
+      type: "dashboard",
+      paramsList: [{ workspaceId: 7, filters: { active: true } }],
+    });
     expect(result).toBeUndefined();
   });
 
   it("handles an empty paramsList without inserting anything", () => {
     const { store, inserts } = makeFakeQueryStore();
-    expect(() => defaultQueryProcessor([], store, "dashboard", [])).not.toThrow();
+    expect(() =>
+      defaultQueryProcessor([], { store, type: "dashboard", paramsList: [] }),
+    ).not.toThrow();
     expect(inserts).toEqual([]);
   });
 });

--- a/packages/silo/tests/processors/json-api.test.ts
+++ b/packages/silo/tests/processors/json-api.test.ts
@@ -53,7 +53,7 @@ describe("jsonApiProcessor", () => {
     // synthesize a JSON-API-shaped envelope here.)
     const userWithType = { ...makeUser("1"), type: "user" as const };
 
-    jsonApiProcessor({ data: [userWithType] }, store, "user");
+    jsonApiProcessor({ data: [userWithType] }, { store, type: "user", ids: [] });
 
     expect(inserts).toEqual([{ type: "user", doc: userWithType }]);
   });
@@ -63,7 +63,10 @@ describe("jsonApiProcessor", () => {
     const userWithType = { ...makeUser("1"), type: "user" as const };
     const postWithType = { ...makePost("10"), type: "post" as const };
 
-    jsonApiProcessor({ data: [userWithType], included: [postWithType] }, store, "user");
+    jsonApiProcessor(
+      { data: [userWithType], included: [postWithType] },
+      { store, type: "user", ids: [] },
+    );
 
     expect(inserts).toEqual([
       { type: "user", doc: userWithType },
@@ -75,7 +78,7 @@ describe("jsonApiProcessor", () => {
     const { store, inserts } = makeFakeStore();
     const userWithType = { ...makeUser("1"), type: "user" as const };
 
-    jsonApiProcessor({ data: [userWithType] }, store, "user");
+    jsonApiProcessor({ data: [userWithType] }, { store, type: "user", ids: [] });
 
     expect(inserts).toEqual([{ type: "user", doc: userWithType }]);
   });
@@ -84,7 +87,7 @@ describe("jsonApiProcessor", () => {
     const { store, inserts } = makeFakeStore();
     const postWithType = { ...makePost("10"), type: "post" as const };
 
-    jsonApiProcessor({ data: [], included: [postWithType] }, store, "user");
+    jsonApiProcessor({ data: [], included: [postWithType] }, { store, type: "user", ids: [] });
 
     expect(inserts).toEqual([{ type: "post", doc: postWithType }]);
   });
@@ -96,7 +99,10 @@ describe("jsonApiProcessor", () => {
     const post11 = { ...makePost("11"), type: "post" as const };
     const user2 = { ...makeUser("2"), type: "user" as const };
 
-    jsonApiProcessor({ data: [userWithType], included: [post10, post11, user2] }, store, "user");
+    jsonApiProcessor(
+      { data: [userWithType], included: [post10, post11, user2] },
+      { store, type: "user", ids: [] },
+    );
 
     expect(inserts).toHaveLength(4);
     const byType = inserts.reduce<Record<string, number>>(
@@ -109,7 +115,7 @@ describe("jsonApiProcessor", () => {
   it("returns void — the library looks up resolved docs from memory afterwards", () => {
     const { store } = makeFakeStore();
     const userWithType = { ...makeUser("1"), type: "user" as const };
-    const result = jsonApiProcessor({ data: [userWithType] }, store, "user");
+    const result = jsonApiProcessor({ data: [userWithType] }, { store, type: "user", ids: [] });
     expect(result).toBeUndefined();
   });
 
@@ -120,7 +126,7 @@ describe("jsonApiProcessor", () => {
     const { store, inserts } = makeFakeStore();
     const postWithType = { ...makePost("10"), type: "post" as const };
 
-    jsonApiProcessor({ data: [], included: [postWithType] }, store, "user");
+    jsonApiProcessor({ data: [], included: [postWithType] }, { store, type: "user", ids: [] });
 
     expect(inserts[0]?.type).toBe("post");
   });
@@ -131,7 +137,7 @@ describe("jsonApiProcessor", () => {
     const postWithType = { ...makePost("10"), type: "post" as const };
 
     // No `data` key at all — only `included`
-    jsonApiProcessor({ included: [postWithType] } as any, store, "user");
+    jsonApiProcessor({ included: [postWithType] } as any, { store, type: "user", ids: [] });
 
     // Only the included doc was inserted (data defaulted to [])
     expect(inserts).toHaveLength(1);
@@ -147,7 +153,7 @@ describe("jsonApiProcessor", () => {
     const u2 = { ...makeUser("2"), type: "user" as const };
     const u3 = { ...makeUser("3"), type: "user" as const };
 
-    jsonApiProcessor({ data: [u1, u2, u3] }, store, "user");
+    jsonApiProcessor({ data: [u1, u2, u3] }, { store, type: "user", ids: [] });
 
     expect(inserts).toEqual([
       { type: "user", doc: u1 },
@@ -159,7 +165,7 @@ describe("jsonApiProcessor", () => {
   it("handles an empty envelope ({}) without throwing or inserting anything", () => {
     const { store, inserts } = makeFakeStore();
 
-    expect(() => jsonApiProcessor({} as any, store, "user")).not.toThrow();
+    expect(() => jsonApiProcessor({} as any, { store, type: "user", ids: [] })).not.toThrow();
     expect(inserts).toEqual([]);
   });
 });

--- a/packages/silo/tests/queries.test.ts
+++ b/packages/silo/tests/queries.test.ts
@@ -26,6 +26,7 @@ import { Effect } from "effect";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
+import { defaultQueryProcessor } from "../src/processors";
 import { createDocumentStore } from "../src/store";
 import {
   API_BASE,
@@ -363,7 +364,7 @@ describe("Queries share memory with documents", () => {
               })),
             ),
           },
-          processor: (raw, store, type, paramsList) => {
+          processor: (raw, { store, type, paramsList }) => {
             const results = raw as Array<{
               userId: string;
               embeddedUser: { id: string; name: string };
@@ -688,5 +689,160 @@ describe("query key stability (stableStringify)", () => {
     // Same params, keys declared in the opposite order → same slot.
     const reordered = { tag: "x", at } as { at: Date; tag: string };
     expect(store.findQueryInMemory("events", reordered)).toEqual({ n: 7 });
+  });
+});
+
+// =============================================================================
+// Query processor pipeline
+//
+// The query surface gets the same ordered pipeline as documents: `processors`
+// run in order after the adapter resolves, each may mutate / replace / side-
+// effect / insert, undefined passes through, and a throw stops the pipeline
+// with a ProcessorError. The context carries `paramsList` (not `ids`).
+// =============================================================================
+
+type PipelineTypes = { user: { id: string; name: string } };
+type PipelineQueries = { search: { params: { q: string }; result: { hits: Array<string> } } };
+
+/** A query adapter whose response is computed from the batch's paramsList. */
+function searchAdapter(fn: (paramsList: Array<{ q: string }>) => unknown) {
+  return { find: effectFind("search", async (paramsList: Array<{ q: string }>) => fn(paramsList)) };
+}
+
+const emptyUserModel = { user: { adapter: { find: effectFind("user", async () => []) } } };
+
+describe("query processor pipeline", () => {
+  it("runs processors in order, threading paramsList and response replacements", async () => {
+    const order: Array<number> = [];
+    let sawParams: ReadonlyArray<{ q: string }> | undefined;
+    const store = createDocumentStore<PipelineTypes, PipelineQueries>({
+      models: emptyUserModel,
+      queries: {
+        search: {
+          // Adapter returns a raw envelope; the first processor reshapes it.
+          adapter: searchAdapter((paramsList) => paramsList.map((p) => ({ raw: p.q }))),
+          processors: [
+            (response, { paramsList }) => {
+              order.push(0);
+              sawParams = paramsList;
+              return (response as Array<{ raw: string }>).map((r) => ({ hits: [r.raw] }));
+            },
+            (response, { store, type, paramsList }) => {
+              order.push(1);
+              const results = response as Array<{ hits: Array<string> }>;
+              for (let i = 0; i < paramsList.length; i++) {
+                store.insertQueryResult(type, paramsList[i], results[i]);
+              }
+            },
+          ],
+        },
+      },
+    });
+
+    const handle = store.findQuery("search", { q: "hello" });
+    await flushCoalescer();
+    await handle.promise;
+
+    expect(order).toEqual([0, 1]);
+    expect(sawParams).toEqual([{ q: "hello" }]);
+    expect(handle.value).toEqual({ hits: ["hello"] });
+  });
+
+  it("passes the response through unchanged when a query processor returns undefined", async () => {
+    const seen: Array<unknown> = [];
+    const store = createDocumentStore<PipelineTypes, PipelineQueries>({
+      models: emptyUserModel,
+      queries: {
+        search: {
+          adapter: searchAdapter((paramsList) => paramsList.map((p) => ({ hits: [p.q] }))),
+          processors: [
+            (response) => {
+              seen.push(response);
+              // No return → pass-through.
+            },
+            (response, { store, type, paramsList }) => {
+              seen.push(response);
+              const results = response as Array<{ hits: Array<string> }>;
+              for (let i = 0; i < paramsList.length; i++) {
+                store.insertQueryResult(type, paramsList[i], results[i]);
+              }
+            },
+          ],
+        },
+      },
+    });
+
+    const handle = store.findQuery("search", { q: "x" });
+    await flushCoalescer();
+    await handle.promise;
+
+    expect(seen[0]).toBe(seen[1]); // same reference flowed through
+    expect(handle.value).toEqual({ hits: ["x"] });
+  });
+
+  it("stops the pipeline on a thrown query processor and fails with a ProcessorError", async () => {
+    const ran: Array<string> = [];
+    const store = createDocumentStore<PipelineTypes, PipelineQueries>({
+      models: emptyUserModel,
+      queries: {
+        search: {
+          adapter: searchAdapter(() => []),
+          processors: [
+            () => {
+              ran.push("first");
+            },
+            () => {
+              ran.push("boom");
+              throw new Error("query-pipeline-exploded");
+            },
+            () => {
+              ran.push("insert");
+            },
+          ],
+        },
+      },
+    });
+
+    const handle = store.findQuery("search", { q: "x" });
+    await flushCoalescer();
+    await handle.promise!.catch(() => {});
+
+    expect(ran).toEqual(["first", "boom"]); // the step after the throw never ran
+    expect(handle.error?._tag).toBe("ProcessorError");
+    const cause = (handle.error as { cause?: unknown }).cause;
+    expect((cause as Error).message).toBe("query-pipeline-exploded");
+  });
+
+  it("throws at store creation when a query sets both `processor` and `processors`", () => {
+    expect(() =>
+      createDocumentStore<PipelineTypes, PipelineQueries>({
+        models: emptyUserModel,
+        queries: {
+          search: {
+            adapter: searchAdapter(() => []),
+            processor: () => {},
+            processors: [() => {}],
+          },
+        },
+      }),
+    ).toThrow(/both `processor` and `processors`/);
+  });
+
+  it("treats `processors: [defaultQueryProcessor]` the same as the implicit default", async () => {
+    const store = createDocumentStore<PipelineTypes, PipelineQueries>({
+      models: emptyUserModel,
+      queries: {
+        search: {
+          adapter: searchAdapter((paramsList) => paramsList.map((p) => ({ hits: [p.q] }))),
+          processors: [defaultQueryProcessor],
+        },
+      },
+    });
+
+    const handle = store.findQuery("search", { q: "z" });
+    await flushCoalescer();
+    await handle.promise;
+
+    expect(handle.value).toEqual({ hits: ["z"] });
   });
 });

--- a/packages/silo/tests/queries.test.ts
+++ b/packages/silo/tests/queries.test.ts
@@ -845,4 +845,23 @@ describe("query processor pipeline", () => {
 
     expect(handle.value).toEqual({ hits: ["z"] });
   });
+
+  it("runs nothing for an explicit empty `processors: []` — handle settles to NotFoundError", async () => {
+    const store = createDocumentStore<PipelineTypes, PipelineQueries>({
+      models: emptyUserModel,
+      queries: {
+        search: {
+          adapter: searchAdapter((paramsList) => paramsList.map((p) => ({ hits: [p.q] }))),
+          processors: [],
+        },
+      },
+    });
+
+    const handle = store.findQuery("search", { q: "x" });
+    await flushCoalescer();
+    await handle.promise!.catch(() => {});
+
+    expect(handle.value).toBeUndefined();
+    expect(handle.error?._tag).toBe("NotFoundError");
+  });
 });


### PR DESCRIPTION
## Summary

Adds an ordered array of Silo response processors to **both surfaces** — `ModelConfig` (documents) and `QueryConfig` (queries) — making the fetch lifecycle explicit and letting apps compose response work in execution order:

```ts
"card-stack": {
  adapter: cardStackAdapter,
  processors: [
    migrateCardStackResponse(),                 // mutate fetched docs in place
    mirrorResponseDocumentsToEmber(emberStore), // side effect: hydrate another store
    jsonApiProcessor,                           // insert into silo
  ],
}
```

That reads literally: fetch → migrate → mirror → insert. Previously a single `processor` had to carry every responsibility, obscuring the lifecycle.

## What changed

- **`ModelConfig.processors` / `QueryConfig.processors`** — an ordered processor pipeline run in declared order after `adapter.find(...)` resolves. The existing single `processor` field still works and is normalized to a one-element pipeline (`config.processors ?? [config.processor ?? defaultProcessor]`). Both surfaces share one `resolvePipeline` helper.
- **Pipeline semantics** — each processor may mutate the response, **return a replacement** (handed to later processors), perform side effects, or insert into the store. Returning `undefined`/`null` passes the current response through unchanged. Most pipelines end with an insertion processor.
- **Mutually exclusive config** — setting **both** `processor` and `processors` on a model or query throws at store creation (validated eagerly in the `Finder` constructor, alongside the existing `maxConcurrency` check), so ambiguous config fails fast.
- **Error semantics preserved** — a processor throw stops the pipeline (remaining processors don't run) and fails the chunk with a `ProcessorError`, identical to a single-`processor` throw today.
- **Processor signatures** are now `(response, context) => unknown | void`:
  - `ResponseProcessor` (documents): `context` is `{ store, type, ids }` (was `(raw, store, type) => void`).
  - `QueryProcessor` (queries): `context` is `{ store, type, paramsList }` (was `(raw, store, type, paramsList) => void`).
  
  The bundled `defaultProcessor` / `jsonApiProcessor` / `defaultQueryProcessor` and any config using them are unaffected. New `ProcessorContext` and `QueryProcessorContext` types are exported for typing custom processors.

## Default behavior unchanged

These remain equivalent: `{ adapter }`, `{ adapter, processor: defaultProcessor }`, `{ adapter, processors: [defaultProcessor] }` — on both surfaces.

## Tests

New `processor pipeline` suite in `tests/finder.test.ts` and `query processor pipeline` suite in `tests/queries.test.ts` cover ordered execution (+ `ids` / `paramsList` in context), response replacement, pass-through on `undefined`, side-effect-only processors, insertion processors, thrown-error termination, the both-set config throw, and default equivalence. The direct-call processor unit tests were updated to the new context signature.

## Checks

All green locally: `pnpm test` (704), `pnpm run test:validate` (5), `pnpm run typecheck` (all packages), `pnpm lint`, `pnpm format`. Changeset added (`@supergrain/silo` minor).

## Notes / review callouts

- **Bump level** — landed as a **minor** changeset, consistent with prior silo type-shape refinements in the 5.x line (e.g. the resilience-engine changeset). The signature change is technically breaking for *hand-written* custom processors using the old positional args; flagged prominently in the changeset body so it can be bumped to major if preferred.
- `?? response` treats a `null` return as pass-through too (matching the spec's literal runner), so a processor can't replace the response with `null`.

https://claude.ai/code/session_01ECkRmDNyUqa1qNhN6Z6o2P