### PR TITLE
fix(silo): make stored documents reactive in place (remove the freeze)

### DIFF
--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -154,10 +154,18 @@ The whole engine — batch window included — runs on Effect's clock (`Effect.s
 
 ### Updating documents
 
-Documents are **immutable snapshots, replaced wholesale.** To change one, call `insertDocument(type, newDoc)` with a _new_ object — every handle referencing that `(type, id)` re-renders, no query-key invalidation, no network call.
+Stored documents are **live and reactive at field granularity** — the same fine-grained reactivity as the rest of `@supergrain/kernel`. `handle.value` hands back a reactive proxy of the cached object, so reading `handle.value.attributes.firstName` subscribes to _that field_, and there are two ways to update a document — both reactive, no query-key invalidation, no network call:
+
+**1. Mutate a field in place.** Only the readers of that field re-render.
 
 ```ts
-// Edit user #42 — build a new object, don't mutate the cached one.
+const user = store.findInMemory("user", "42")!;
+user.attributes.firstName = "Ada"; // re-renders only firstName readers
+```
+
+**2. Replace the whole document.** Insert a _new_ object; every reader of the document re-renders.
+
+```ts
 const prev = store.findInMemory("user", "42")!;
 store.insertDocument("user", {
   ...prev,
@@ -165,14 +173,9 @@ store.insertDocument("user", {
 });
 ```
 
-This is **whole-document reactivity**: reading `handle.value` (or any field off it) re-renders when the document is replaced. There's no per-field tracking _inside_ a document — the snapshot is swapped atomically, so every read sees a consistent object.
+Reach for in-place when you're editing one field and want the tightest possible re-render; reach for wholesale replace when a socket push or mutation response hands you a fresh object. `insertDocument` writes `handle.value` only when the reference actually changes, so swapping in a new object always notifies, while an in-place field write notifies through that field's own signal.
 
-Don't mutate a stored document in place — always build a new object. Stored docs are **frozen**, so a top-level in-place write (`doc.id = …`) is rejected — a `TypeError` in strict mode (which ESM and bundled app code always use) — instead of silently corrupting the cache. Two reasons this matters:
-
-1. **It keeps the contract honest.** Insert applies a new value only when the reference actually changes (`applyEvent` skips the write otherwise), so mutating-and-reinserting the _same_ object would silently fail to re-render. The freeze turns that latent no-op into a loud error.
-2. **It preserves reference identity.** The kernel's reactive proxy returns frozen targets unwrapped, so `handle.value` hands back the exact object you inserted — stable `===` for memoization and dependency arrays.
-
-The freeze is shallow: a _nested_ write (`doc.attributes.name = …`) won't throw, it just silently breaks reactivity. Either way the rule is the same — never edit a cached document, spread into a new one (as above).
+No copy is made on insert — the object you pass _is_ the cached target, just handed back through a reactive proxy (`unwrap(handle.value)` recovers the exact reference). Documents are **not frozen**: a frozen object is the one thing the kernel hands back _unwrapped_, which would drop it out of the reactive graph — so if you freeze a doc yourself before inserting it, you opt that document out of per-field tracking and in-place updates.
 
 ## Why this instead of TanStack Query / SWR?
 

--- a/packages/silo/src/store.ts
+++ b/packages/silo/src/store.ts
@@ -562,22 +562,22 @@ export function createDocumentStore<
     },
 
     insertDocument<K extends keyof M & string>(type: K, doc: M[K]): void {
-      // Freeze stored docs to pin the wholesale-replace contract: a document is
-      // an immutable snapshot, updated only by inserting a NEW object — which
-      // swaps `handle.value` and re-renders readers — never by mutating in
-      // place. Two payoffs:
-      //   1. `applyEvent` writes `handle.value` only when the reference changes
-      //      (`raw.value !== value` guard in transitions.ts), so mutating and
-      //      reinserting the same object would silently fail to re-render.
-      //      Freezing turns that latent no-op into a loud throw in strict mode
-      //      (which ESM/bundled code always is; sloppy mode fails silently).
-      //      The freeze is shallow, so only top-level writes throw — the
-      //      wholesale-replace rule stands.
-      //   2. `createReactiveProxy` returns frozen targets unwrapped (read.ts),
-      //      so `handle.value` hands back this exact object — stable `===`
-      //      identity for consumers that memoize on it.
-      if (!Object.isFrozen(doc)) Object.freeze(doc);
-
+      // Stored docs are LIVE and reactive at field granularity — not frozen
+      // snapshots. The kernel wraps the inserted object in a reactive proxy
+      // (read.ts), so a `handle.value.<field>` read subscribes to just that
+      // field, and there are two ways to update a document:
+      //   1. Mutate a field in place (`handle.value.attributes.name = "Ada"`).
+      //      Fine-grained: only readers of that field re-render. The write goes
+      //      through the proxy's signal, so no reinsert is needed.
+      //   2. Insert a NEW object. Wholesale replace; readers of the whole doc
+      //      re-render. `applyEvent` writes `handle.value` only when the
+      //      reference actually changes (`raw.value !== value` in
+      //      transitions.ts), so swapping in a fresh object always notifies.
+      // No copy is made — the inserted object IS the stored target (unwrap the
+      // handle's value to recover the exact reference). We deliberately do NOT
+      // freeze: a frozen target is handed back unwrapped by the kernel
+      // (`createReactiveProxy` bails on `Object.isFrozen`), which would kill
+      // per-field reactivity and the in-place update path above.
       batch(() => {
         const handle = getOrCreateHandle(ensureBucket(state.documents, type), doc.id);
         applyEvent(handle, HandleEvent.insert(doc));
@@ -625,13 +625,10 @@ export function createDocumentStore<
       params: Q[K]["params"],
       result: Q[K]["result"],
     ): void {
-      // Same wholesale-replace contract as insertDocument (see there): freeze
-      // the result so it's an immutable snapshot the kernel hands back by
-      // identity. Guarded for null / non-object results, which can't be frozen.
-      if (result !== null && typeof result === "object" && !Object.isFrozen(result)) {
-        Object.freeze(result);
-      }
-
+      // Like insertDocument: query results are live and reactive — not frozen.
+      // An object result is wrapped in a reactive proxy by the kernel, so reads
+      // track the fields they touch and an in-place mutation re-renders just
+      // those subscribers. Update in place or insert a fresh result; both work.
       const paramsKey = stableStringify(params);
       batch(() => {
         const handle = getOrCreateHandle(ensureBucket(state.queries, type), paramsKey);

--- a/packages/silo/tests/property.test.ts
+++ b/packages/silo/tests/property.test.ts
@@ -1,3 +1,4 @@
+import { unwrap } from "@supergrain/kernel";
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
@@ -97,7 +98,7 @@ describe("silo property-based tests", () => {
 
         store.insertQueryResult("search", params, result);
 
-        expect(store.findQueryInMemory("search", reordered)).toBe(result);
+        expect(unwrap(store.findQueryInMemory("search", reordered))).toBe(result);
         expect(store.findQuery("search", params)).toBe(store.findQuery("search", reordered));
       }),
       { numRuns: 100 },

--- a/packages/silo/tests/queries.test.ts
+++ b/packages/silo/tests/queries.test.ts
@@ -21,7 +21,7 @@
 // pin the contract the implementation must meet.
 // =============================================================================
 
-import { effect } from "@supergrain/kernel";
+import { effect, unwrap } from "@supergrain/kernel";
 import { Effect } from "effect";
 import { http, HttpResponse } from "msw";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -222,7 +222,9 @@ describe("DocumentStore.insertQueryResult + findQueryInMemory", () => {
 
     store.insertQueryResult("dashboard", params, result);
 
-    expect(store.findQueryInMemory("dashboard", params)).toBe(result);
+    // The stored result is the exact object inserted (no copy), handed back
+    // through a reactive proxy — unwrap to compare raw identity.
+    expect(unwrap(store.findQueryInMemory("dashboard", params))).toBe(result);
   });
 
   it("overwrites at the same slot (last-write-wins)", () => {
@@ -259,7 +261,7 @@ describe("DocumentStore.insertQueryResult + findQueryInMemory", () => {
     const result = makeDashboard({ totalActiveUsers: 42 });
     store.insertQueryResult("dashboard", p1, result);
 
-    expect(store.findQueryInMemory("dashboard", p2)).toBe(result);
+    expect(unwrap(store.findQueryInMemory("dashboard", p2))).toBe(result);
   });
 });
 
@@ -439,7 +441,7 @@ describe("Queries share memory with documents", () => {
     store.insertQueryResult("dashboard", params, result);
 
     expect(handle.value).not.toBeUndefined();
-    expect(handle.value).toBe(result);
+    expect(unwrap(handle.value)).toBe(result); // reactive proxy over the exact object
     // A fresh value supersedes any prior error: the error clears and status
     // flips to success.
     expect(handle.error).toBeUndefined();

--- a/packages/silo/tests/store.test.ts
+++ b/packages/silo/tests/store.test.ts
@@ -1,4 +1,4 @@
-import { effect } from "@supergrain/kernel";
+import { effect, unwrap } from "@supergrain/kernel";
 import { http, HttpResponse } from "msw";
 import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
 
@@ -66,7 +66,9 @@ describe("Store memory operations", () => {
     const user = makeUser("1");
     store.insertDocument("user", user);
 
-    expect(store.findInMemory("user", "1")).toBe(user);
+    // The stored value is the exact object inserted (no copy), handed back
+    // through a reactive proxy — unwrap to compare raw identity.
+    expect(unwrap(store.findInMemory("user", "1"))).toBe(user);
   });
 
   it("findInMemory returns undefined for a missing document", () => {
@@ -113,7 +115,7 @@ describe("Store.find — already in memory (fast path)", () => {
     const handle = store.find("user", "1");
 
     expect(handle.value).not.toBeUndefined();
-    expect(handle.value).toBe(user);
+    expect(unwrap(handle.value)).toBe(user); // reactive proxy over the exact object
     expect(handle.isFetching).toBe(false);
     expect(handle.status).toBe("success");
 
@@ -122,25 +124,44 @@ describe("Store.find — already in memory (fast path)", () => {
   });
 });
 
-describe("Store.insertDocument — immutability contract", () => {
-  it("freezes the stored document so a top-level in-place mutation throws", () => {
+describe("Store.insertDocument — documents are live and reactive", () => {
+  it("does NOT freeze the stored document — a field can be mutated in place", () => {
     const user = makeUser("1");
     store.insertDocument("user", user);
 
     const stored = store.findInMemory("user", "1")!;
-    // Frozen: the wholesale-replace contract can't be bypassed by mutation.
-    expect(Object.isFrozen(stored)).toBe(true);
-    // Returned by reference (the kernel hands frozen targets back unwrapped),
-    // so the === identity consumers memoize on holds.
-    expect(stored).toBe(user);
-    // A top-level write is rejected loudly (strict mode) rather than silently
-    // corrupting the cache and skipping the re-render past applyEvent's guard.
+    // Not frozen: the document stays in the reactive graph (a frozen target is
+    // handed back unwrapped by the kernel, dropping per-field reactivity).
+    expect(Object.isFrozen(unwrap(stored))).toBe(false);
+    // No copy: the stored value is the exact object inserted, behind a proxy.
+    expect(unwrap(stored)).toBe(user);
+    // A top-level write succeeds (no throw) and lands on the underlying object.
     expect(() => {
-      stored.id = "mutated";
-    }).toThrow();
+      stored.attributes.firstName = "Ada";
+    }).not.toThrow();
+    expect(stored.attributes.firstName).toBe("Ada");
+    expect(user.attributes.firstName).toBe("Ada"); // same underlying object
   });
 
-  it("accepts an already-frozen document", () => {
+  it("re-renders only the readers of a field mutated in place", () => {
+    store.insertDocument("user", makeUser("1", { firstName: "User1" }));
+    const handle = store.find("user", "1");
+
+    const firstNameReads: Array<string | undefined> = [];
+    effect(() => {
+      firstNameReads.push(handle.value?.attributes.firstName);
+    });
+    expect(firstNameReads).toEqual(["User1"]);
+
+    // Mutate the field in place — the field subscriber re-fires, no reinsert.
+    store.findInMemory("user", "1")!.attributes.firstName = "Ada";
+    expect(firstNameReads.at(-1)).toBe("Ada");
+  });
+
+  it("accepts an already-frozen document the consumer froze (opts out of reactivity)", () => {
+    // The store never freezes for you, but it tolerates a consumer-frozen doc:
+    // it round-trips by reference (frozen targets are returned unwrapped) — at
+    // the cost of per-field reactivity, which is the consumer's choice.
     const user = Object.freeze(makeUser("2"));
     expect(() => store.insertDocument("user", user)).not.toThrow();
     expect(store.findInMemory("user", "2")).toBe(user);
@@ -381,7 +402,7 @@ describe("Store.insertDocument — updates IDLE and ERROR handles to SUCCESS", (
     store.insertDocument("user", user);
 
     expect(handle.value).not.toBeUndefined();
-    expect(handle.value).toBe(user);
+    expect(unwrap(handle.value)).toBe(user); // reactive proxy over the exact object
     expect(handle.isFetching).toBe(false);
     expect(handle.status).toBe("success");
   });
@@ -402,7 +423,7 @@ describe("Store.insertDocument — updates IDLE and ERROR handles to SUCCESS", (
     store.insertDocument("user", user);
 
     expect(handle.value).not.toBeUndefined();
-    expect(handle.value).toBe(user);
+    expect(unwrap(handle.value)).toBe(user); // reactive proxy over the exact object
     // A fresh value supersedes any prior error: error is cleared and the
     // handle's status flips to success.
     expect(handle.error).toBeUndefined();

--- a/packages/silo/tests/store.test.ts
+++ b/packages/silo/tests/store.test.ts
@@ -125,7 +125,7 @@ describe("Store.find — already in memory (fast path)", () => {
 });
 
 describe("Store.insertDocument — documents are live and reactive", () => {
-  it("does NOT freeze the stored document — a field can be mutated in place", () => {
+  it("does NOT freeze the stored document — it can be mutated in place", () => {
     const user = makeUser("1");
     store.insertDocument("user", user);
 
@@ -135,27 +135,38 @@ describe("Store.insertDocument — documents are live and reactive", () => {
     expect(Object.isFrozen(unwrap(stored))).toBe(false);
     // No copy: the stored value is the exact object inserted, behind a proxy.
     expect(unwrap(stored)).toBe(user);
-    // A top-level write succeeds (no throw) and lands on the underlying object.
+    // A top-level write succeeds. The old freeze was shallow — it rejected
+    // exactly this top-level write while letting nested writes through — so a
+    // top-level write (not a nested one) is what proves the doc is unfrozen.
     expect(() => {
-      stored.attributes.firstName = "Ada";
+      stored.attributes = { ...user.attributes, firstName: "Ada" };
     }).not.toThrow();
     expect(stored.attributes.firstName).toBe("Ada");
     expect(user.attributes.firstName).toBe("Ada"); // same underlying object
   });
 
-  it("re-renders only the readers of a field mutated in place", () => {
-    store.insertDocument("user", makeUser("1", { firstName: "User1" }));
+  it("re-renders only the readers of the field mutated in place", () => {
+    store.insertDocument("user", makeUser("1", { firstName: "User1", lastName: "Original" }));
     const handle = store.find("user", "1");
 
     const firstNameReads: Array<string | undefined> = [];
     effect(() => {
       firstNameReads.push(handle.value?.attributes.firstName);
     });
+    const lastNameReads: Array<string | undefined> = [];
+    effect(() => {
+      lastNameReads.push(handle.value?.attributes.lastName);
+    });
     expect(firstNameReads).toEqual(["User1"]);
+    expect(lastNameReads).toEqual(["Original"]);
 
-    // Mutate the field in place — the field subscriber re-fires, no reinsert.
+    // Mutate only firstName in place — the firstName subscriber re-fires, no
+    // reinsert; the sibling lastName subscriber does NOT re-run. That second
+    // assertion is the "only" in fine-grained: coarse, whole-doc tracking would
+    // re-run both.
     store.findInMemory("user", "1")!.attributes.firstName = "Ada";
     expect(firstNameReads.at(-1)).toBe("Ada");
+    expect(lastNameReads).toEqual(["Original"]); // never re-ran
   });
 
   it("accepts an already-frozen document the consumer froze (opts out of reactivity)", () => {


### PR DESCRIPTION
## What & why

`insertDocument` / `insertQueryResult` were calling `Object.freeze` on the stored object. Because the kernel hands frozen targets back **unwrapped** (`createReactiveProxy` bails on `Object.isFrozen`, `packages/kernel/src/read.ts:210`), a frozen document never gets a reactive proxy — so:

- reads off `handle.value` were **not** tracked per field, and
- in-place mutation was impossible.

This was the opposite of what silo should be. Documents live in the same fine-grained reactive graph as the rest of `@supergrain/kernel`.

### How it got there
- The freeze was present in silo's **first** commit (#63, `6065b78`), justified solely as *"preserving reference identity for consumers that compare handle.data to the doc they inserted."* It froze the doc purely to get `handle.value === insertedDoc` — without reckoning that freezing is exactly how you eject an object from the reactive graph.
- A later docs PR (#94, `b1bf09c`) found the unexplained freeze and **rationalized** it into a documented "immutable snapshots / wholesale-replace / don't mutate in place" contract, plus tests asserting `Object.isFrozen(stored) === true` and that mutation throws. A questionable one-liner became gospel.

## Changes
- **Remove the freeze** from `insertDocument` and `insertQueryResult`. The stored object now comes back through a live reactive proxy:
  - **In place** — `handle.value.attributes.firstName = "Ada"` re-renders only that field's readers.
  - **Wholesale** — insert a new object; whole-doc readers re-render (`applyEvent` still writes only when the reference changes).
  - No copy is made — `unwrap(handle.value)` recovers the exact inserted object.
- **README** — rewrite the "Updating documents" section: in-place vs wholesale, both reactive; note that a consumer-frozen doc opts itself out of reactivity.
- **Tests** — replace the freeze-contract tests with real in-place reactivity tests (mutate a field → only its readers re-render; doc is no longer frozen). Update identity assertions to `unwrap(...).toBe(inserted)` now that values come back proxied (`store`, `queries`, `property` test files).

## Checks
All five project checks pass locally: `pnpm test` (707), `pnpm run test:validate`, `pnpm run typecheck`, `pnpm lint`, `pnpm format`.

## Note / open question
Removing the freeze means `handle.value !== theRawObjectYouInserted` (it's a stable reactive proxy; `unwrap()` recovers the raw object). That `===`-to-the-raw-input identity was the freeze's original (only) motivation. If any downstream code compares `handle.value` to a raw inserted object with `===`, it should unwrap first. Flagging in case that tradeoff needs a wider look.

https://claude.ai/code/session_01HaS1wtNK5FJxcVMP897QPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaS1wtNK5FJxcVMP897QPG)_