### PR TITLE
chore(silo): changeset for reactive-in-place documents (major → 6.0.0)

### DIFF
--- a/.changeset/silo-reactive-documents.md
+++ b/.changeset/silo-reactive-documents.md
@@ -1,0 +1,16 @@
+---
+"@supergrain/silo": major
+---
+
+Stored documents and query results are now **live and reactive in place** — `insertDocument` / `insertQueryResult` no longer `Object.freeze` the value they store.
+
+Silo sits on `@supergrain/kernel`'s fine-grained reactivity, but freezing the stored object opted it out of that graph: the kernel hands frozen targets back unwrapped, so reads off `handle.value` weren't tracked per field and in-place mutation was impossible. Removing the freeze restores the kernel's native behavior:
+
+- **Mutate a field in place** — `handle.value.attributes.name = "Ada"` re-renders only the readers of that field.
+- **Replace wholesale** — inserting a new object still re-renders whole-document readers, as before.
+- No copy is made on insert; `unwrap(handle.value)` recovers the exact object you inserted.
+
+**BREAKING CHANGE.** Two previously documented guarantees are gone:
+
+- `handle.value` is now a **reactive proxy** of the stored object, not the raw object you passed to `insertDocument`. `handle.value === insertedDoc` no longer holds — use `unwrap(handle.value)` if you need the raw reference. (Proxy identity is still stable across reads, so memoizing on `handle.value` is unaffected.)
+- Stored documents are **no longer frozen**. `Object.isFrozen(handle.value)` is now `false`, and a write that previously threw (top-level, strict mode) now succeeds and updates the cache reactively. If you want a document to stay immutable, freeze it yourself before inserting — but note that opts it out of per-field reactivity.


### PR DESCRIPTION
Adds the changeset that PR #101 ("make stored documents reactive in place — remove the freeze") landed without, so a release can be cut.

- **Bump:** `major` on `@supergrain/silo`. The packages are a **fixed** version group, so this takes all five (`kernel`, `silo`, `mill`, `husk`, `queries`) from `5.1.0` → **`6.0.0`**.
- **Why major:** the change removes two previously documented guarantees — `handle.value === insertedDoc` reference identity (now a stable reactive proxy; use `unwrap()` for the raw object) and frozen/immutable stored docs (now mutable in place).

Merging this will trigger the Changesets action to open/update the **"Release: Version Packages"** PR; merging that one publishes the release.

https://claude.ai/code/session_01HaS1wtNK5FJxcVMP897QPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaS1wtNK5FJxcVMP897QPG)_