### PR TITLE
feat(silo/react): let Provider adopt a pre-built store via `store` prop

### DIFF
--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -267,7 +267,7 @@ Because `@supergrain/queries` stores its result envelopes through `insertDocumen
 
 ### `createDocumentStoreContext<S extends DocumentStore<any, any>>()`
 
-The React context wrapper. Mirrors `createStoreContext<T>()` from `@supergrain/kernel/react`: the type parameter `S` is the store type; the Provider takes the same `config` you'd pass to `createDocumentStore()` and constructs the store internally once per mount. Pass `store` instead of `config` to adopt a store you built outside React (SSR setup, a pre-React imperative handle, or one shared across trees); provide exactly one of the two.
+The React context wrapper. Mirrors `createStoreContext<T>()` from `@supergrain/kernel/react`: the type parameter `S` is the store type; the Provider takes the same `config` you'd pass to `createDocumentStore()` and constructs the store internally once per mount. Pass `store` instead of `config` to adopt a store _instance_ you built outside React — to share one store across multiple React roots, or drive it from non-React code. `config` and `store` are the two ends of one pipeline (recipe vs. built store), so provide exactly one of the two — passing both throws.
 
 ```ts
 type DocStore = DocumentStore<TypeToModel, TypeToQuery>;
@@ -332,7 +332,7 @@ From `@supergrain/silo/react`:
 
 All returned from `createDocumentStoreContext<S>()`; destructure and re-export from your store module.
 
-- `Provider({ config?, store?, initial?, onMount?, children })` — provide exactly one of `config` (wrapped in `createDocumentStore()` exactly once per mount) or `store` (an existing store, adopted as-is — for SSR setup or sharing across trees); supplying neither throws. Optional `initial` seeds documents/query results before the first render; optional `onMount` runs synchronously after seeding for imperative setup. Both run regardless of which source supplied the store.
+- `Provider({ config?, store?, initial?, onMount?, children })` — provide exactly one of `config` (wrapped in `createDocumentStore()` exactly once per mount) or `store` (an existing store instance, adopted as-is — to share one store across multiple React roots or drive it from non-React code); supplying neither, or both, throws. Optional `initial` seeds documents/query results before the first render; optional `onMount` runs synchronously after seeding for imperative setup. Both run regardless of which source supplied the store.
 - `useDocument(type, id | null | undefined)` → `DocumentHandle<T>`. `null`/`undefined` id returns an idle handle (useful for conditional fetching — `useDocument("user", isLoggedIn ? myId : null)`). "Idle" isn't a separate `status`: the handle reads `status: "pending"` with `isFetching: false` (detect it as `status === "pending" && !isFetching` if you need to). There's no `"IDLE"` status — it folded onto the orthogonal `isFetching` axis.
 - `useDocumentStore()` → store API. Escape hatch for imperative ops (`insertDocument`, `clearMemory`, query methods).
 - `useQuery(type, params | null | undefined)` → `QueryHandle<Result>`. Same null-handling as `useDocument`.

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -267,7 +267,7 @@ Because `@supergrain/queries` stores its result envelopes through `insertDocumen
 
 ### `createDocumentStoreContext<S extends DocumentStore<any, any>>()`
 
-The React context wrapper. Mirrors `createStoreContext<T>()` from `@supergrain/kernel/react`: the type parameter `S` is the store type; the Provider takes the same `config` you'd pass to `createDocumentStore()` and constructs the store internally once per mount.
+The React context wrapper. Mirrors `createStoreContext<T>()` from `@supergrain/kernel/react`: the type parameter `S` is the store type; the Provider takes the same `config` you'd pass to `createDocumentStore()` and constructs the store internally once per mount. Pass `store` instead of `config` to adopt a store you built outside React (SSR setup, a pre-React imperative handle, or one shared across trees); provide exactly one of the two.
 
 ```ts
 type DocStore = DocumentStore<TypeToModel, TypeToQuery>;
@@ -332,7 +332,7 @@ From `@supergrain/silo/react`:
 
 All returned from `createDocumentStoreContext<S>()`; destructure and re-export from your store module.
 
-- `Provider({ config, initial?, onMount?, children })` — wraps `config` in `createDocumentStore()` exactly once per mount. Optional `initial` seeds documents/query results before the first render; optional `onMount` runs synchronously after seeding for imperative setup.
+- `Provider({ config?, store?, initial?, onMount?, children })` — provide exactly one of `config` (wrapped in `createDocumentStore()` exactly once per mount) or `store` (an existing store, adopted as-is — for SSR setup or sharing across trees); supplying neither throws. Optional `initial` seeds documents/query results before the first render; optional `onMount` runs synchronously after seeding for imperative setup. Both run regardless of which source supplied the store.
 - `useDocument(type, id | null | undefined)` → `DocumentHandle<T>`. `null`/`undefined` id returns an idle handle (useful for conditional fetching — `useDocument("user", isLoggedIn ? myId : null)`). "Idle" isn't a separate `status`: the handle reads `status: "pending"` with `isFetching: false` (detect it as `status === "pending" && !isFetching` if you need to). There's no `"IDLE"` status — it folded onto the orthogonal `isFetching` axis.
 - `useDocumentStore()` → store API. Escape hatch for imperative ops (`insertDocument`, `clearMemory`, query methods).
 - `useQuery(type, params | null | undefined)` → `QueryHandle<Result>`. Same null-handling as `useDocument`.

--- a/packages/silo/src/react/index.ts
+++ b/packages/silo/src/react/index.ts
@@ -74,10 +74,18 @@ function seedQueries<M extends DocumentTypes, Q extends QueryTypes>(
  * exactly once per mount. Every SSR request, every test, every React tree
  * gets an isolated store by construction.
  *
+ * Pass `store` instead of `config` to adopt a store you built outside React —
+ * for SSR setup, an imperative handle held before React mounts, or one shared
+ * across trees — and the Provider binds that instance to context as-is rather
+ * than constructing a new one. Provide exactly one of `config` or `store`;
+ * supplying neither throws.
+ *
  * Optional `initial` seeds documents and query results before the first
  * render. Optional `onMount` runs synchronously after seeding for imperative
- * setup (preloads, subscriptions). Both run inside the `useState`
- * initializer, so under React StrictMode in dev they are double-invoked —
+ * setup (preloads, subscriptions). Both run regardless of whether the store
+ * was constructed from `config` or adopted via `store`, and both run inside
+ * the `useState` initializer, so under React StrictMode in dev (and on an
+ * adopted store that's shared across trees) they may run more than once —
  * keep them idempotent.
  *
  * @example
@@ -98,7 +106,8 @@ export function createDocumentStoreContext<
   >,
 >(): {
   Provider: (props: {
-    config: DocumentStoreConfig<ModelsOf<S>, QueriesOf<S>>;
+    config?: DocumentStoreConfig<ModelsOf<S>, QueriesOf<S>>;
+    store?: S;
     initial?: InitialDocumentStoreData<ModelsOf<S>, QueriesOf<S>>;
     onMount?: (store: S) => void;
     children: ReactNode;
@@ -120,17 +129,36 @@ export function createDocumentStoreContext<
 
   function Provider({
     config,
+    store: providedStore,
     initial,
     onMount,
     children,
   }: {
-    config: DocumentStoreConfig<M, Q>;
+    config?: DocumentStoreConfig<M, Q>;
+    store?: S;
     initial?: InitialDocumentStoreData<M, Q>;
     onMount?: (store: S) => void;
     children: ReactNode;
   }): ReactNode {
     const [store] = useState<S>(() => {
-      const s = createDocumentStore<M, Q>(config);
+      // Two ways to get the store: construct it from `config` (the common case
+      // — one isolated store per mount), or adopt a `store` the caller built
+      // outside React (SSR prep, a pre-React imperative handle, or one shared
+      // across trees). One source is required; with neither there's nothing to
+      // bind.
+      if (config === undefined && providedStore === undefined) {
+        throw new Error(
+          "@supergrain/silo/react: createDocumentStoreContext Provider requires either a `config` (to construct a store) or a `store` (to adopt an existing one)",
+        );
+      }
+      // Adopt the caller's store when given — narrowing the S upcast back to the
+      // concrete DocumentStore<M, Q>, the same cast useDocument/useQuery use — or
+      // construct one from config. `initial` seeding and `onMount` then run the
+      // same way regardless of source, so the props stay orthogonal.
+      const s =
+        providedStore === undefined
+          ? createDocumentStore<M, Q>(config as DocumentStoreConfig<M, Q>)
+          : (providedStore as unknown as DocumentStore<M, Q>);
       if (initial?.model) seedModels(s, initial.model);
       if (initial?.query) seedQueries(s, initial.query);
       const typedStore = s as unknown as S;

--- a/packages/silo/src/react/index.ts
+++ b/packages/silo/src/react/index.ts
@@ -64,11 +64,13 @@ function seedQueries<M extends DocumentTypes, Q extends QueryTypes>(
 }
 
 /**
- * Resolve the store a Provider binds to context. Two sources: adopt the
- * caller's pre-built `store` (built outside React — SSR prep, a pre-React
- * imperative handle, or one shared across trees), or construct one from
- * `config` (the common case — an isolated store per mount). Exactly one is
- * required; with neither there's nothing to bind, so this throws.
+ * Resolve the store a Provider binds to context. `config` and `store` are the
+ * two ends of one pipeline — `config` is the recipe, `store` is the result of
+ * `createDocumentStore(config)` — so exactly one is required: construct from
+ * `config` (the common case — an isolated store per mount), or adopt a pre-built
+ * `store`. With neither there's nothing to bind; with both the `config` would be
+ * redundant (an adopted store already has its config baked in). Either violation
+ * throws.
  *
  * `store` arrives as the caller's `S`, which by construction extends
  * `DocumentStore<DocumentTypes, QueryTypes>`; narrow it to the concrete
@@ -78,6 +80,11 @@ function resolveStore<M extends DocumentTypes, Q extends QueryTypes>(
   config: DocumentStoreConfig<M, Q> | undefined,
   store: DocumentStore<DocumentTypes, QueryTypes> | undefined,
 ): DocumentStore<M, Q> {
+  if (config !== undefined && store !== undefined) {
+    throw new Error(
+      "@supergrain/silo/react: createDocumentStoreContext Provider takes exactly one of `config` (to construct a store) or `store` (to adopt an existing one), not both — an adopted store already has its config baked in",
+    );
+  }
   if (store !== undefined) return store as unknown as DocumentStore<M, Q>;
   if (config !== undefined) return createDocumentStore<M, Q>(config);
   throw new Error(
@@ -96,11 +103,13 @@ function resolveStore<M extends DocumentTypes, Q extends QueryTypes>(
  * exactly once per mount. Every SSR request, every test, every React tree
  * gets an isolated store by construction.
  *
- * Pass `store` instead of `config` to adopt a store you built outside React —
- * for SSR setup, an imperative handle held before React mounts, or one shared
- * across trees — and the Provider binds that instance to context as-is rather
- * than constructing a new one. Provide exactly one of `config` or `store`;
- * supplying neither throws.
+ * Pass `store` instead of `config` to adopt a store instance you built outside
+ * React — to share one store across multiple React roots, or to drive it from
+ * non-React code — and the Provider binds that instance to context as-is rather
+ * than constructing a new one. (For a Provider-owned store, `config` with
+ * `initial`/`onMount` already covers seeding and imperative setup.) `config`
+ * and `store` are the two ends of one pipeline (recipe vs. built store), so
+ * provide exactly one — supplying neither, or both, throws.
  *
  * Optional `initial` seeds documents and query results before the first
  * render. Optional `onMount` runs synchronously after seeding for imperative

--- a/packages/silo/src/react/index.ts
+++ b/packages/silo/src/react/index.ts
@@ -64,6 +64,28 @@ function seedQueries<M extends DocumentTypes, Q extends QueryTypes>(
 }
 
 /**
+ * Resolve the store a Provider binds to context. Two sources: adopt the
+ * caller's pre-built `store` (built outside React — SSR prep, a pre-React
+ * imperative handle, or one shared across trees), or construct one from
+ * `config` (the common case — an isolated store per mount). Exactly one is
+ * required; with neither there's nothing to bind, so this throws.
+ *
+ * `store` arrives as the caller's `S`, which by construction extends
+ * `DocumentStore<DocumentTypes, QueryTypes>`; narrow it to the concrete
+ * `DocumentStore<M, Q>` (the same upcast `useDocument`/`useQuery` use).
+ */
+function resolveStore<M extends DocumentTypes, Q extends QueryTypes>(
+  config: DocumentStoreConfig<M, Q> | undefined,
+  store: DocumentStore<DocumentTypes, QueryTypes> | undefined,
+): DocumentStore<M, Q> {
+  if (store !== undefined) return store as unknown as DocumentStore<M, Q>;
+  if (config !== undefined) return createDocumentStore<M, Q>(config);
+  throw new Error(
+    "@supergrain/silo/react: createDocumentStoreContext Provider requires either a `config` (to construct a store) or a `store` (to adopt an existing one)",
+  );
+}
+
+/**
  * Create an isolated document-store React binding — Context + Provider + hooks,
  * all tied to a fresh React Context that doesn't collide with any other call
  * to this factory.
@@ -141,24 +163,10 @@ export function createDocumentStoreContext<
     children: ReactNode;
   }): ReactNode {
     const [store] = useState<S>(() => {
-      // Two ways to get the store: construct it from `config` (the common case
-      // — one isolated store per mount), or adopt a `store` the caller built
-      // outside React (SSR prep, a pre-React imperative handle, or one shared
-      // across trees). One source is required; with neither there's nothing to
-      // bind.
-      if (config === undefined && providedStore === undefined) {
-        throw new Error(
-          "@supergrain/silo/react: createDocumentStoreContext Provider requires either a `config` (to construct a store) or a `store` (to adopt an existing one)",
-        );
-      }
-      // Adopt the caller's store when given — narrowing the S upcast back to the
-      // concrete DocumentStore<M, Q>, the same cast useDocument/useQuery use — or
-      // construct one from config. `initial` seeding and `onMount` then run the
-      // same way regardless of source, so the props stay orthogonal.
-      const s =
-        providedStore === undefined
-          ? createDocumentStore<M, Q>(config as DocumentStoreConfig<M, Q>)
-          : (providedStore as unknown as DocumentStore<M, Q>);
+      // Resolve which store to use (construct from config, or adopt the
+      // provided one), then seed + mount it the same way regardless of source —
+      // so `initial` and `onMount` stay orthogonal to how the store was got.
+      const s = resolveStore<M, Q>(config, providedStore);
       if (initial?.model) seedModels(s, initial.model);
       if (initial?.query) seedQueries(s, initial.query);
       const typedStore = s as unknown as S;

--- a/packages/silo/tests/react/index.test.tsx
+++ b/packages/silo/tests/react/index.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   AdapterError,
+  createDocumentStore,
   type DocumentStore,
   type DocumentStoreConfig,
   type QueryAdapter,
@@ -480,6 +481,86 @@ describe("Provider initial data seeding", () => {
     );
 
     expect(screen.getByTestId("q").textContent).toBe(String(result.totalActiveUsers));
+  });
+});
+
+// =============================================================================
+// Provider `store` prop — adopt a store built outside React instead of
+// constructing one from `config`. Useful for SSR setup, an imperative handle
+// held before React mounts, or one store shared across trees.
+// =============================================================================
+
+describe("Provider store prop", () => {
+  it("adopts a pre-built store — hooks read from the provided instance", () => {
+    const store = createDocumentStore<TypeToModel, TypeToQuery>(makeStoreConfig());
+    store.insertDocument("user", makeUser("1", { firstName: "Prebuilt" }));
+
+    render(
+      <Provider store={store}>
+        <UserBadge userId="1" />
+      </Provider>,
+    );
+
+    // No `config` was constructed — the badge reads the doc that was inserted
+    // into the externally-built store before render.
+    expect(screen.getByText("Prebuilt")).toBeDefined();
+  });
+
+  it("shares one adopted store across two Providers", () => {
+    const store = createDocumentStore<TypeToModel, TypeToQuery>(makeStoreConfig());
+
+    // Write-only seed — plain component, not `tracked` (see SeedUser note).
+    function Seed() {
+      const s = useDocumentStore();
+      s.insertDocument("user", makeUser("1", { firstName: "Shared" }));
+      return null;
+    }
+
+    render(
+      <>
+        <Provider store={store}>
+          <Seed />
+        </Provider>
+        <Provider store={store}>
+          <UserBadge userId="1" />
+        </Provider>
+      </>,
+    );
+
+    // Both Providers adopt the same instance, so a doc the first tree seeded is
+    // visible in the second. A `config`-constructed Provider would isolate them.
+    expect(screen.getByText("Shared")).toBeDefined();
+  });
+
+  it("applies `initial` seeding and `onMount` against an adopted store", () => {
+    const store = createDocumentStore<TypeToModel, TypeToQuery>(makeStoreConfig());
+    let mountedWith: DocumentStore<TypeToModel, TypeToQuery> | null = null;
+
+    render(
+      <Provider
+        store={store}
+        initial={{ model: { user: { "1": makeUser("1", { firstName: "Seeded" }) } } }}
+        onMount={(s) => {
+          mountedWith = s;
+        }}
+      >
+        <UserBadge userId="1" />
+      </Provider>,
+    );
+
+    expect(screen.getByText("Seeded")).toBeDefined();
+    // onMount received the very store we passed in, not a fresh construction.
+    expect(mountedWith).toBe(store);
+  });
+
+  it("throws when neither config nor store is provided", () => {
+    expect(() =>
+      render(
+        <Provider>
+          <span>child</span>
+        </Provider>,
+      ),
+    ).toThrow(/requires either a .config.*or a .store./);
   });
 });
 

--- a/packages/silo/tests/react/index.test.tsx
+++ b/packages/silo/tests/react/index.test.tsx
@@ -562,6 +562,21 @@ describe("Provider store prop", () => {
       ),
     ).toThrow(/requires either a .config.*or a .store./);
   });
+
+  it("throws when both config and store are provided", () => {
+    // `config` and `store` are the two ends of one pipeline; an adopted store
+    // already has its config baked in, so supplying both is a contradiction.
+    // Both props are optional, so this is type-legal — the guard is runtime.
+    const store = createDocumentStore<TypeToModel, TypeToQuery>(makeStoreConfig());
+
+    expect(() =>
+      render(
+        <Provider config={makeStoreConfig()} store={store}>
+          <span>child</span>
+        </Provider>,
+      ),
+    ).toThrow(/exactly one of .config.*or .store.*not both/);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`createDocumentStoreContext().Provider` could only construct its store internally from `config`. This PR adds an alternative `store` prop so callers can **adopt a `DocumentStore` they built outside React** — for SSR setup, an imperative handle held before React mounts, or one store shared across trees — and bind that instance to context as-is.

### Background

This came in as a request to "just add `store?: S` to the Provider's type, the runtime already supports it." That premise turned out to be **incorrect**: on both `main` and this branch the `Provider` always calls `createDocumentStore(config)` — there is no `store` destructuring anywhere. Applying the type-only change would have compiled but then crashed at runtime (passing `store` with no `config` would call `createDocumentStore(undefined)`). So this implements the feature end-to-end instead.

## Changes

- **`config` is now optional**; provide exactly one of `config` or `store`. Supplying neither throws a descriptive error from the `useState` initializer.
- When `store` is given, the Provider binds that instance directly (narrowing the `S` upcast back to the concrete `DocumentStore<M, Q>`, the same cast `useDocument`/`useQuery` use).
- **`initial` seeding and `onMount` run the same way regardless of source**, so the props stay orthogonal to how the store was obtained. The JSDoc notes these may run more than once on a shared/adopted store (as under StrictMode) — keep them idempotent.
- Updated the `createDocumentStoreContext` JSDoc and the silo README Provider docs.

## Tests

Added to `packages/silo/tests/react/index.test.tsx`:
- adopts a pre-built store — hooks read from the provided instance
- shares one adopted store across two Providers
- applies `initial` seeding and `onMount` against an adopted store
- throws when neither `config` nor `store` is provided

## Verification

All five required checks pass locally:

- `pnpm test` — 728 passed
- `pnpm run test:validate` — 5 passed
- `pnpm run typecheck` — clean across all packages
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format` — clean

https://claude.ai/code/session_01RmbFQd3q69EDUNrs4TW5qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmbFQd3q69EDUNrs4TW5qb)_