### PR TITLE
chore(silo): changeset for Provider `store` prop (minor → 6.2.0)

### DIFF
--- a/.changeset/silo-provider-store-prop.md
+++ b/.changeset/silo-provider-store-prop.md
@@ -1,0 +1,9 @@
+---
+"@supergrain/silo": minor
+---
+
+feat(silo/react): `createDocumentStoreContext` Provider can adopt a pre-built store
+
+The Provider now accepts a `store` prop as an alternative to `config`: pass a `DocumentStore` instance you constructed yourself (via `createDocumentStore`) and the Provider binds it to context as-is instead of constructing one. This is for the cases `config` can't serve — sharing one store instance across multiple React roots, or driving it from non-React code. (`config` paired with `initial`/`onMount` still covers SSR data transfer and in-tree imperative setup.)
+
+`config` and `store` are the two ends of one pipeline (a recipe vs. the store built from it), so they're mutually exclusive: provide exactly one. Supplying neither — or both — throws. `config` is now optional, which is a backward-compatible change (existing `config`-only usage is unaffected).


### PR DESCRIPTION
## Summary

Adds the changeset for the `createDocumentStoreContext` Provider `store` prop (merged in #110), which shipped without one. This is the entry point for cutting the release.

- **Bump:** `minor` (new `store` prop is backward-compatible; existing `config`-only usage is unaffected). `config` going from required → optional is also non-breaking.
- **Effect:** the `fixed` package group (`kernel`, `mill`, `silo`, `husk`, `queries`) bumps **6.1.0 → 6.2.0** in lockstep. The changelog entry lands on `@supergrain/silo` (the only package that changed).

## Release flow

Merging this changeset onto `main` triggers the **Release** workflow, which opens a **"Release: Version Packages"** PR with the version bumps + changelog entries. Merging *that* PR publishes to npm (via trusted publishing / OIDC).

https://claude.ai/code/session_01RmbFQd3q69EDUNrs4TW5qb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmbFQd3q69EDUNrs4TW5qb)_