### PR TITLE
fix(release): link benchmark packages to workspace kernel so 6.3.0 can publish

### DIFF
--- a/packages/js-krauset-main/package.json
+++ b/packages/js-krauset-main/package.json
@@ -11,7 +11,7 @@
     "perf:stats": "node perf-stats.ts"
   },
   "dependencies": {
-    "@supergrain/kernel": "6.3.0",
+    "@supergrain/kernel": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/packages/js-krauset/package.json
+++ b/packages/js-krauset/package.json
@@ -14,7 +14,7 @@
     "perf:analyze": "node perf-profile.ts"
   },
   "dependencies": {
-    "@supergrain/kernel": "6.3.0",
+    "@supergrain/kernel": "workspace:*",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
   packages/js-krauset:
     dependencies:
       '@supergrain/kernel':
-        specifier: 6.2.0
-        version: 6.2.0(arktype@2.2.0)(react@19.2.4)
+        specifier: workspace:*
+        version: link:../kernel
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -324,8 +324,8 @@ importers:
   packages/js-krauset-main:
     dependencies:
       '@supergrain/kernel':
-        specifier: 6.2.0
-        version: 6.2.0(arktype@2.2.0)(react@19.2.4)
+        specifier: workspace:*
+        version: link:../kernel
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1936,17 +1936,6 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
-
-  '@supergrain/kernel@6.2.0':
-    resolution: {integrity: sha512-DftKA97U2ofOTeK3CmZy9uNOa7tCKw+jkF97bE92MGnvY3NalCOV2pFwIS2bgikbfABevDgMtM5R4cApGuZxSg==}
-    peerDependencies:
-      arktype: '>=2.0.0'
-      react: ^18.2.0 || ^19.0.0
-    peerDependenciesMeta:
-      arktype:
-        optional: true
-      react:
-        optional: true
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -5151,13 +5140,6 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
-
-  '@supergrain/kernel@6.2.0(arktype@2.2.0)(react@19.2.4)':
-    dependencies:
-      alien-signals: 3.2.1
-    optionalDependencies:
-      arktype: 2.2.0
-      react: 19.2.4
 
   '@swc/helpers@0.5.23':
     dependencies:


### PR DESCRIPTION
## Why

The `Release: Version Packages (#114)` merge bumped all `@supergrain/*` packages to **6.3.0**, but the publish run [failed in ~24s](https://github.com/commoncurriculum/supergrain/actions/runs/27788591982) at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/js-krauset/package.json
```

`packages/js-krauset` and `packages/js-krauset-main` pinned a **published** `@supergrain/kernel` version (registry-resolved, since pnpm 10 defaults `link-workspace-packages` to false). During `changeset version`, changesets rewrote those pins `6.2.0` → `6.3.0` — a version that isn't published yet — without regenerating the lockfile. So the frozen install can't resolve `6.3.0` and the job dies **before** building or publishing. Nothing shipped to npm; `main` was just left half-released. This would recur on every release.

## What

Switch `@supergrain/kernel` to `workspace:*` in both benchmark packages (matching `js-krauset-react-hooks`, which was unaffected). The lockfile now links `link:../kernel`, so frozen installs stay consistent across version bumps. Vite source-aliases remain removed (from #117), so the bundles still build against kernel's `dist`.

Merging this re-triggers the `Release` workflow; with no pending changesets it runs `pnpm release` and publishes **6.3.0** + creates the GitHub Releases.

## Verification (local)

- `pnpm install --frozen-lockfile` — passes (lockfile up to date)
- `pnpm test` — 790 passed (54 files)
- `pnpm run test:validate` — 5 passed
- `pnpm run typecheck` — pass
- `pnpm lint` — 0 warnings / 0 errors
- `pnpm run format:check` — clean
- `pnpm run build` — all published packages build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MkizQgNuqHDvSfGxKz14y

---
_Generated by [Claude Code](https://claude.ai/code/session_017MkizQgNuqHDvSfGxKz14y)_