### PR TITLE
fix(mill): preserve document prototype flavor in undo snapshots and fabricated branches

### DIFF
--- a/.changeset/mill-prototype-fidelity.md
+++ b/.changeset/mill-prototype-fidelity.md
@@ -1,0 +1,10 @@
+---
+"@supergrain/mill": patch
+---
+
+Prototype fidelity: mill no longer imposes `Object.prototype` on documents that don't use it.
+
+- Undo snapshots are now taken with a prototype-faithful clone instead of `structuredClone`, which silently normalized every object to `Object.prototype` — so rewinding an update on a null-prototype document corrupted its flavor. Snapshots now restore the prior state exactly, prototype included (shared references within a snapshot are preserved; Dates still clone as Dates).
+- Intermediate branches fabricated by a deep `$set`/`$inc`/... on a missing path now match the document's flavor (a null-prototype document grows null-prototype branches) instead of hardcoding `{}`.
+
+Mill remains reference-semantics for values: `$set`/`$push`/`$addToSet` still store exactly the objects you pass, no copying.

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -131,6 +131,9 @@ export function resolveParentPath(
 
 export function ensureParentPath(target: object, path: string): { parent: any; key: string } {
   const parts = splitPath(path);
+  // Fabricated branches match the document's flavor: a null-prototype document
+  // grows null-prototype branches, a plain-object document grows plain ones.
+  const branchPrototype = Object.getPrototypeOf(target) === null ? null : Object.prototype;
   let current: any = target;
 
   for (let i = 0; i < parts.length - 1; i++) {
@@ -145,7 +148,7 @@ export function ensureParentPath(target: object, path: string): { parent: any; k
           setProperty(current, String(j), null);
         }
       }
-      setProperty(current, part, {});
+      setProperty(current, part, Object.create(branchPrototype));
     } else if (!isContainer(existing)) {
       // A scalar (number/string/boolean/null) can't gain a subfield: Mongo
       // rejects rather than silently overwriting it. e.g. {a: 42} + "a.b".

--- a/packages/mill/src/util.ts
+++ b/packages/mill/src/util.ts
@@ -82,10 +82,42 @@ export function isEqual(a: unknown, b: unknown): boolean {
  * Snapshot a value so a captured undo fragment can't be corrupted by later
  * in-place mutation of the live document. Primitives pass through untouched;
  * containers are deep-cloned.
+ *
+ * The clone is prototype-faithful: each object is recreated with its own
+ * prototype, so a null-prototype object snapshots (and therefore restores) as
+ * null-prototype and a plain object as plain. `structuredClone` is unsuitable
+ * here — it silently normalizes every object to `Object.prototype`, so
+ * replaying an undo would corrupt a null-prototype document's flavor. Shared
+ * references (and cycles) within one snapshot are preserved via `seen`.
+ *
+ * The supported domain matches `isEqual`'s: primitives, `Date`s, arrays, and
+ * structural objects. Exotic containers with internal slots (`Map`, `Set`) are
+ * not valid mill document values and won't survive the clone.
  */
-export function cloneValue<V>(value: V): V {
+export function cloneValue<V>(value: V, seen = new WeakMap<object, unknown>()): V {
   if (value === null || typeof value !== "object") {
     return value;
   }
-  return structuredClone(value);
+  const already = seen.get(value);
+  if (already !== undefined) {
+    return already as V;
+  }
+  if (value instanceof Date) {
+    return new Date(value) as V;
+  }
+  if (Array.isArray(value)) {
+    const copy: Array<unknown> = [];
+    seen.set(value, copy);
+    for (const item of value) {
+      copy.push(cloneValue(item, seen));
+    }
+    return copy as V;
+  }
+  const source = value as Record<string, unknown>;
+  const copy: Record<string, unknown> = Object.create(Object.getPrototypeOf(source));
+  seen.set(value, copy);
+  for (const key of Object.keys(source)) {
+    copy[key] = cloneValue(source[key], seen);
+  }
+  return copy as V;
 }

--- a/packages/mill/src/util.ts
+++ b/packages/mill/src/util.ts
@@ -119,7 +119,12 @@ export function cloneValue<V>(value: V, seen = new WeakMap<object, unknown>()): 
   const copy: Record<string, unknown> = Object.create(Object.getPrototypeOf(source));
   seen.set(value, copy);
   for (const key of Object.keys(source)) {
-    copy[key] = cloneValue(source[key], seen);
+    Object.defineProperty(copy, key, {
+      value: cloneValue(source[key], seen),
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
   return copy as V;
 }

--- a/packages/mill/src/util.ts
+++ b/packages/mill/src/util.ts
@@ -103,7 +103,9 @@ export function cloneValue<V>(value: V, seen = new WeakMap<object, unknown>()): 
     return already as V;
   }
   if (value instanceof Date) {
-    return new Date(value) as V;
+    const dateCopy = new Date(value);
+    seen.set(value, dateCopy);
+    return dateCopy as V;
   }
   if (Array.isArray(value)) {
     const copy: Array<unknown> = [];

--- a/packages/mill/tests/prototype-fidelity.test.ts
+++ b/packages/mill/tests/prototype-fidelity.test.ts
@@ -96,6 +96,17 @@ describe("undo snapshots preserve prototype flavor", () => {
     const raw = unwrap(store) as Record<string, any>;
     expect(raw.items[0]).toBe(raw.items[1]);
   });
+
+  it("preserves shared Date references within one snapshot", () => {
+    const shared = new Date("2026-01-02T03:04:05Z");
+    const store = createReactive({ dates: [shared, shared] });
+
+    const { undo } = update(store, {}, { $set: { dates: [] } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.dates[0]).toBe(raw.dates[1]);
+  });
 });
 
 describe("fabricated intermediate branches match the document's flavor", () => {

--- a/packages/mill/tests/prototype-fidelity.test.ts
+++ b/packages/mill/tests/prototype-fidelity.test.ts
@@ -1,0 +1,122 @@
+import { createReactive, unwrap } from "@supergrain/kernel";
+import { describe, expect, it } from "vitest";
+
+import { update } from "../src";
+
+// Mill never decides a document's prototype flavor — it follows it. These
+// tests pin the two places that could silently impose `Object.prototype` on a
+// null-prototype document: undo snapshots (which must restore the prior state
+// *exactly*, prototype included) and fabricated intermediate branches (which
+// must match the document they're created in). Prototypes don't exist in BSON,
+// so none of this goes through the mongo oracle — raw `update` only.
+
+function nullProto<T extends Record<string, unknown>>(entries: T): T {
+  const out = Object.create(null) as T;
+  for (const key of Object.keys(entries)) {
+    (out as Record<string, unknown>)[key] = entries[key];
+  }
+  return out;
+}
+
+function protoOf(value: unknown): object | null {
+  return Object.getPrototypeOf(value) as object | null;
+}
+
+describe("undo snapshots preserve prototype flavor", () => {
+  it("$set overwrite of a null-prototype object restores it null-prototype", () => {
+    const store = createReactive(
+      nullProto({ attributes: nullProto({ nested: nullProto({ value: 1 }) }) }),
+    );
+
+    const { undo } = update(store, {}, { $set: { attributes: { replaced: true } } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.attributes.nested.value).toBe(1);
+    expect(protoOf(raw.attributes)).toBeNull();
+    expect(protoOf(raw.attributes.nested)).toBeNull();
+  });
+
+  it("$set overwrite of a plain object restores it plain", () => {
+    const store = createReactive({ attributes: { nested: { value: 1 } } });
+
+    const { undo } = update(store, {}, { $set: { attributes: { replaced: true } } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(protoOf(raw.attributes)).toBe(Object.prototype);
+    expect(protoOf(raw.attributes.nested)).toBe(Object.prototype);
+  });
+
+  it("$pop restores a null-prototype element null-prototype", () => {
+    const store = createReactive(nullProto({ items: [nullProto({ id: "a" })] }));
+
+    const { undo } = update(store, {}, { $pop: { items: 1 } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.items).toEqual([{ id: "a" }]);
+    expect(protoOf(raw.items[0])).toBeNull();
+  });
+
+  it("$pull restores removed null-prototype elements null-prototype", () => {
+    const store = createReactive(
+      nullProto({ items: [nullProto({ id: "a" }), nullProto({ id: "b" })] }),
+    );
+
+    const { undo } = update(store, {}, { $pull: { items: { id: "a" } } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.items).toEqual([{ id: "a" }, { id: "b" }]);
+    expect(protoOf(raw.items[0])).toBeNull();
+    expect(protoOf(raw.items[1])).toBeNull();
+  });
+
+  it("restores Dates as Dates", () => {
+    const when = new Date("2026-01-02T03:04:05Z");
+    const store = createReactive({ at: when });
+
+    const { undo } = update(store, {}, { $set: { at: new Date(0) } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.at).toBeInstanceOf(Date);
+    expect(raw.at.getTime()).toBe(when.getTime());
+    expect(raw.at).not.toBe(when); // snapshot, not the live reference
+  });
+
+  it("preserves shared references within one snapshot", () => {
+    const shared = { id: "s" };
+    const store = createReactive({ items: [shared, shared] });
+
+    const { undo } = update(store, {}, { $set: { items: [] } } as never);
+    update(store, {}, undo);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.items[0]).toBe(raw.items[1]);
+  });
+});
+
+describe("fabricated intermediate branches match the document's flavor", () => {
+  it("a null-prototype document grows null-prototype branches", () => {
+    const store = createReactive(nullProto({}) as Record<string, unknown>);
+
+    update(store, {}, { $set: { "a.b.c": 1 } } as never);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(raw.a.b.c).toBe(1);
+    expect(protoOf(raw.a)).toBeNull();
+    expect(protoOf(raw.a.b)).toBeNull();
+  });
+
+  it("a plain document grows plain branches", () => {
+    const store = createReactive({} as Record<string, unknown>);
+
+    update(store, {}, { $set: { "a.b.c": 1 } } as never);
+
+    const raw = unwrap(store) as Record<string, any>;
+    expect(protoOf(raw.a)).toBe(Object.prototype);
+    expect(protoOf(raw.a.b)).toBe(Object.prototype);
+  });
+});


### PR DESCRIPTION
## Why

Consumers that keep documents prototype-free (null-prototype plain objects) get their flavor silently corrupted by two mill internals — even when every value they hand mill is already prototype-free:

1. **Undo snapshots** used `structuredClone`, which normalizes every object to `Object.prototype`. Rewinding an update therefore `$set` prototype-carrying copies back into the document. For an engine whose undo contract is "restores the prior state *exactly*," this is a fidelity bug regardless of flavor.
2. **Fabricated intermediate branches** (deep `$set`/`$inc`/`$push` on a missing path) were hardcoded `{}`.

Found while centralizing prototype-freedom for supergrain documents in the v4 app: silo's `prepareInsert` hook covers every insert, and the app strips its own patch values — but these two sites are unreachable from the outside.

## What

- `cloneValue` (undo snapshots) is now a prototype-faithful deep clone: each object is recreated with its own prototype, so null-proto snapshots restore null-proto and plain restores plain. Shared references within a snapshot are preserved via a `WeakMap`; `Date`s still clone as `Date`s. Supported domain matches `isEqual`'s (primitives, Dates, arrays, structural objects) — exotic containers with internal slots (`Map`/`Set`) were never valid mill document values and won't survive the clone, where `structuredClone` used to copy them.
- `ensureParentPath` fabricates missing branches matching the document root's flavor instead of hardcoding `{}`.

Deliberately **not** changed: mill remains reference-semantics for values. `$set`/`$push`/`$addToSet` store exactly the objects the caller passes; whether and how to copy stays the caller's decision.

## Tests

`tests/prototype-fidelity.test.ts` pins both guarantees across the distinct `cloneValue` call sites ($set overwrite, $pop, $pull), Date round-trips, shared-reference identity, and branch fabrication in both flavors. These stay off the mongo oracle (prototypes don't exist in BSON). Full suite: 265/265 passing including oracle parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)