### PR TITLE
feat: allowNullIntermediatesOption

### DIFF
--- a/packages/mill/README.md
+++ b/packages/mill/README.md
@@ -65,13 +65,42 @@ function update<T extends object>(
   doc: T,
   query: Query<T>,
   operations: UpdateOperations<T>,
+  options?: UpdateOptions,
 ): { doc: T; undo: UpdateOperations<T> };
+
+interface UpdateOptions {
+  arrayFilters?: Array<ArrayFilter>;
+  allowNullIntermediates?: boolean;
+}
 ```
 
 - **`doc`** — the document to mutate, in place. A reactive store gets fine-grained signal updates; a plain object is mutated just the same. The same reference is returned as `result.doc`.
 - **`query`** — a Mongo query, used **only** to resolve positional paths (`items.$.name`). It doesn't need to identify the document — that's already selected. Pass `{}` when there are no positional paths.
 - **`operations`** — a standard Mongo update document.
+- **`options`** — optional. `arrayFilters` supplies the filters for the `$[<identifier>]` filtered positional operator. `allowNullIntermediates` is described below.
 - **returns** `{ doc, undo }` — `undo` is a Mongo update document that, applied to the post-update `doc`, restores the exact prior state.
+
+### `allowNullIntermediates`
+
+By default mill is faithful to MongoDB, which **rejects** writing through a `null`. `$set`-ing `"a.b"` when `a` is `null` throws `Cannot create field 'b' in element {a: null}`, and `$push`-ing onto a `null` field throws `The field 'a' must be an array but is of type null`. (A merely _absent_ intermediate is always fine — Mongo, and mill, create the branch.)
+
+Pass `allowNullIntermediates: true` to instead treat a `null` intermediate or target as if the field were **absent** — a deliberate departure from MongoDB:
+
+```ts
+// { attributes: { clipboard: null } }
+update(doc, {}, { $set: { "attributes.clipboard.card": "c1" } }, { allowNullIntermediates: true });
+// → { attributes: { clipboard: { card: "c1" } } }
+
+// { attributes: { cards: null } }
+update(doc, {}, { $push: { "attributes.cards": { id: "x" } } }, { allowNullIntermediates: true });
+// → { attributes: { cards: [{ id: "x" }] } }
+```
+
+- `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects over `null` intermediates.
+- `$push` / `$addToSet` create the array when the target (or an intermediate) is `null`.
+- `$pull` / `$pullAll` / `$pop` no-op on a `null` target, exactly as they do for a missing field.
+
+A present _scalar_ (e.g. `42`) in the way is still an error — only `null` is treated as absent. The generated `undo` restores the prior `null` exactly.
 
 ## Operators
 

--- a/packages/mill/src/array-ops.ts
+++ b/packages/mill/src/array-ops.ts
@@ -1,7 +1,7 @@
 import { setProperty, deleteProperty } from "@supergrain/kernel/internal";
 import { match } from "ts-pattern";
 
-import { getValueAtPath, resolveParentPath, splitPath } from "./path";
+import { getValueAtPath, type PathWriteOptions, resolveParentPath, splitPath } from "./path";
 import { describeValue, isContainer, isObject } from "./util";
 
 // ─── array primitives (fine-grained, in place) ──────────────────────────────
@@ -30,28 +30,38 @@ export interface ArrayTarget {
 // traversal), as opposed to merely absent. A scalar in the way is an error for
 // every array operator; a merely-absent ancestor means the field doesn't exist
 // yet (Mongo creates it for $push/$addToSet, no-ops for $pull/$pullAll/$pop).
-function pathBlockedByScalar(raw: object, path: string): boolean {
+// With `allowNullIntermediates`, a `null` ancestor counts as absent (creatable)
+// too rather than a blocker.
+function pathBlockedByScalar(raw: object, path: string, allowNull: boolean): boolean {
   const parts = splitPath(path);
   let current: unknown = raw;
+  const creatable = (value: unknown): boolean =>
+    value === undefined || (allowNull && value === null);
   for (let i = 0; i < parts.length - 1; i++) {
-    if (current === undefined) {
-      return false; // an absent ancestor — creatable, not blocked
+    if (creatable(current)) {
+      return false; // an absent (or null, when allowed) ancestor — creatable, not blocked
     }
     if (!isContainer(current)) {
       return true; // a scalar ancestor blocks the path
     }
     current = (current as Record<string, unknown>)[parts[i]!];
   }
-  return current !== undefined && !isContainer(current); // a scalar leaf-parent blocks too
+  return !creatable(current) && !isContainer(current); // a scalar leaf-parent blocks too
 }
 
-export function resolveArrayTarget(operator: string, raw: object, path: string): ArrayTarget {
+export function resolveArrayTarget(
+  operator: string,
+  raw: object,
+  path: string,
+  options: PathWriteOptions = {},
+): ArrayTarget {
+  const allowNull = options.allowNullIntermediates ?? false;
   const result = resolveParentPath(raw, path);
   if (!result) {
     // The parent path isn't fully present. A scalar in the way is always an
     // error; a merely-missing intermediate means the field is absent and the
     // caller decides (create vs no-op), exactly like a missing leaf.
-    if (pathBlockedByScalar(raw, path)) {
+    if (pathBlockedByScalar(raw, path, allowNull)) {
       throw new TypeError(
         `${operator} path "${path}" must point to an array — a non-object value blocks the path.`,
       );
@@ -60,13 +70,21 @@ export function resolveArrayTarget(operator: string, raw: object, path: string):
   }
 
   const value = result.parent[result.key];
-  if (value !== undefined && !Array.isArray(value)) {
+  // A `null` target is normally an error; with `allowNullIntermediates` it's
+  // treated as absent so $push/$addToSet create the array and $pull/$pullAll/$pop
+  // no-op (exactly as they do for a missing field).
+  const absent = value === undefined || (allowNull && value === null);
+  if (!absent && !Array.isArray(value)) {
     throw new TypeError(
       `${operator} path "${path}" must point to an array, received ${describeValue(value)}.`,
     );
   }
 
-  return { arr: value as Array<any> | undefined, parent: result.parent, key: result.key };
+  return {
+    arr: absent ? undefined : (value as Array<any>),
+    parent: result.parent,
+    key: result.key,
+  };
 }
 
 export function pushToArray(arr: Array<any>, itemsToAdd: Array<any>): void {

--- a/packages/mill/src/array-ops.ts
+++ b/packages/mill/src/array-ops.ts
@@ -1,4 +1,4 @@
-import { setProperty, deleteProperty } from "@supergrain/kernel/internal";
+import { deleteProperty, setProperty } from "@supergrain/kernel/internal";
 import { match } from "ts-pattern";
 
 import { getValueAtPath, type PathWriteOptions, resolveParentPath, splitPath } from "./path";
@@ -53,9 +53,9 @@ export function resolveArrayTarget(
   operator: string,
   raw: object,
   path: string,
-  options: PathWriteOptions = {},
+  options: PathWriteOptions,
 ): ArrayTarget {
-  const allowNull = options.allowNullIntermediates ?? false;
+  const allowNull = options.allowNullIntermediates;
   const result = resolveParentPath(raw, path);
   if (!result) {
     // The parent path isn't fully present. A scalar in the way is always an

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -132,6 +132,24 @@ export interface UpdateOptions {
    * every supplied filter must be used.
    */
   arrayFilters?: Array<ArrayFilter>;
+
+  /**
+   * Treat a `null` intermediate or target as if the field were *absent* rather
+   * than rejecting it. This is a deliberate **departure from MongoDB**, which
+   * throws in these cases (`Cannot create field 'b' in element {a: null}`, or
+   * `The field 'a' must be an array but is of type null`). When enabled:
+   *
+   *   - `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects
+   *     over `null` intermediates instead of throwing.
+   *   - `$push` / `$addToSet` create the array when the target (or an
+   *     intermediate) is `null`.
+   *   - `$pull` / `$pullAll` / `$pop` no-op on a `null` target (exactly as they
+   *     already do for a missing field).
+   *
+   * The generated `undo` restores the prior `null` exactly. Off by default so
+   * mill stays faithful to MongoDB.
+   */
+  allowNullIntermediates?: boolean;
 }
 
 // Collect the `$[<identifier>]` identifiers referenced in an update document's
@@ -207,8 +225,10 @@ function assertNoPathConflicts(operations: UpdateOperations<any>): void {
  * @param query      A Mongo query used only to resolve positional paths
  *                   (`items.$.name`). Pass `{}` when the update has none.
  * @param operations A standard Mongo update document.
- * @param options    Optional Mongo update options — `arrayFilters` for the
- *                   `$[<identifier>]` filtered positional operator.
+ * @param options    Optional update options — `arrayFilters` for the
+ *                   `$[<identifier>]` filtered positional operator, and
+ *                   `allowNullIntermediates` to treat `null` intermediates as
+ *                   absent (a deliberate departure from MongoDB).
  * @returns          `{ doc, undo }` — `undo` reverses the actual changes made.
  */
 export function update<T extends object>(
@@ -245,7 +265,13 @@ export function update<T extends object>(
     }
   }
 
-  const context: OperatorContext = { raw, undo, query: query as Query, arrayFilters };
+  const context: OperatorContext = {
+    raw,
+    undo,
+    query: query as Query,
+    arrayFilters,
+    allowNullIntermediates: options?.allowNullIntermediates ?? false,
+  };
 
   // Coalesce every write in this call into a single notification.
   batch(() => {

--- a/packages/mill/src/operators/add-to-set.ts
+++ b/packages/mill/src/operators/add-to-set.ts
@@ -2,7 +2,7 @@ import { pushToArray, resolveArrayTarget } from "../array-ops";
 import { setValueAtPath } from "../path";
 import { capturePathUndo, undoTruncate } from "../undo";
 import { isEqual, isObject } from "../util";
-import { eachPath, type OperatorContext } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 function uniqueAdditions(existing: ReadonlyArray<unknown>, candidates: Array<unknown>): Array<any> {
   const additions: Array<any> = [];
@@ -19,14 +19,14 @@ function uniqueAdditions(existing: ReadonlyArray<unknown>, candidates: Array<unk
 
 export function $addToSet(context: OperatorContext, operations: Record<string, any>): void {
   eachPath(context, operations, (path, spec) => {
-    const target = resolveArrayTarget("$addToSet", context.raw, path);
+    const target = resolveArrayTarget("$addToSet", context.raw, path, pathWriteOptions(context));
     const candidates =
       isObject(spec) && "$each" in spec && Array.isArray(spec["$each"]) ? spec["$each"] : [spec];
 
     if (target.arr === undefined) {
       // Absent field — Mongo creates the array with the de-duplicated values.
       capturePathUndo(context.undo, context.raw, path);
-      setValueAtPath(context.raw, path, uniqueAdditions([], candidates));
+      setValueAtPath(context.raw, path, uniqueAdditions([], candidates), pathWriteOptions(context));
       return;
     }
 

--- a/packages/mill/src/operators/pop.ts
+++ b/packages/mill/src/operators/pop.ts
@@ -1,14 +1,14 @@
 import { removeIndices, resolveArrayTarget } from "../array-ops";
 import { undoPushSpec } from "../undo";
 import { cloneValue } from "../util";
-import { eachPath, type OperatorContext } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 export function $pop(context: OperatorContext, operations: Record<string, 1 | -1>): void {
   eachPath(context, operations as Record<string, unknown>, (path, direction) => {
     if (direction !== 1 && direction !== -1) {
       throw new Error(`$pop expects 1 or -1, found: ${JSON.stringify(direction)}`);
     }
-    const { arr } = resolveArrayTarget("$pop", context.raw, path);
+    const { arr } = resolveArrayTarget("$pop", context.raw, path, pathWriteOptions(context));
     if (arr === undefined || arr.length === 0) {
       return; // absent or empty — no-op
     }

--- a/packages/mill/src/operators/push.ts
+++ b/packages/mill/src/operators/push.ts
@@ -4,11 +4,11 @@ import { applyPushModifiers, parsePushSpec, pushToArray, resolveArrayTarget } fr
 import { setValueAtPath } from "../path";
 import { capturePathUndo, undoSet, undoTruncate } from "../undo";
 import { cloneValue, isEqual } from "../util";
-import { eachPath, type OperatorContext } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 export function $push(context: OperatorContext, operations: Record<string, any>): void {
   eachPath(context, operations, (path, spec) => {
-    const target = resolveArrayTarget("$push", context.raw, path);
+    const target = resolveArrayTarget("$push", context.raw, path, pathWriteOptions(context));
     const { items, position, slice, sort } = parsePushSpec(spec);
 
     if (target.arr === undefined) {
@@ -16,7 +16,7 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
       // inverse is to remove the field it created.
       const created = applyPushModifiers([], items, { position, slice, sort });
       capturePathUndo(context.undo, context.raw, path);
-      setValueAtPath(context.raw, path, created);
+      setValueAtPath(context.raw, path, created, pathWriteOptions(context));
       return;
     }
     const { arr } = target;

--- a/packages/mill/src/operators/rename.ts
+++ b/packages/mill/src/operators/rename.ts
@@ -2,7 +2,7 @@ import { deleteValueAtPath, resolveParentPath, setValueAtPath, splitPath } from 
 import { resolvePaths } from "../query";
 import { capturePathUndo, undoSet } from "../undo";
 import { cloneValue, isContainer } from "../util";
-import { type OperatorContext } from "./shared";
+import { type OperatorContext, pathWriteOptions } from "./shared";
 
 interface RenameMove {
   from: string;
@@ -79,6 +79,6 @@ export function $rename(context: OperatorContext, operations: Record<string, str
     capturePathUndo(context.undo, context.raw, to);
     undoSet(context.undo, from, cloneValue(value));
     deleteValueAtPath(context.raw, from);
-    setValueAtPath(context.raw, to, value);
+    setValueAtPath(context.raw, to, value, pathWriteOptions(context));
   }
 }

--- a/packages/mill/src/operators/set.ts
+++ b/packages/mill/src/operators/set.ts
@@ -1,7 +1,7 @@
 import { getValueAtPath, hasValueAtPath, setValueAtPath } from "../path";
 import { capturePathUndo } from "../undo";
 import { isEqual } from "../util";
-import { eachPath, type OperatorContext } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 export function $set(context: OperatorContext, operations: Record<string, unknown>): void {
   eachPath(context, operations, (path, value) => {
@@ -9,6 +9,6 @@ export function $set(context: OperatorContext, operations: Record<string, unknow
       return; // no-op
     }
     capturePathUndo(context.undo, context.raw, path);
-    setValueAtPath(context.raw, path, value);
+    setValueAtPath(context.raw, path, value, pathWriteOptions(context));
   });
 }

--- a/packages/mill/src/operators/shared.ts
+++ b/packages/mill/src/operators/shared.ts
@@ -13,6 +13,17 @@ export interface OperatorContext {
   undo: MutableUndo;
   query: Query;
   arrayFilters: ReadonlyArray<ArrayFilter>;
+  // When set, `null` intermediates/targets are treated as absent — created for
+  // writing operators ($set/$push/$addToSet/…), no-op'd for removals. Off by
+  // default so mill stays faithful to MongoDB.
+  allowNullIntermediates: boolean;
+}
+
+// The subset of an OperatorContext the path-writing helpers care about.
+export function pathWriteOptions(context: OperatorContext): {
+  allowNullIntermediates: boolean;
+} {
+  return { allowNullIntermediates: context.allowNullIntermediates };
 }
 
 // Resolve every path in `operations` (expanding positional `$` / `$[]` /
@@ -68,7 +79,7 @@ export function writeNumeric(context: OperatorContext, path: string, write: Nume
     return; // no-op
   }
   capturePathUndo(context.undo, context.raw, path);
-  setValueAtPath(context.raw, path, next);
+  setValueAtPath(context.raw, path, next, pathWriteOptions(context));
 }
 
 // ─── array removal ($pull / $pullAll) ───────────────────────────────────────
@@ -81,7 +92,7 @@ export function removeByPredicate(
   path: string,
   op: { operator: string; matches: (element: unknown) => boolean },
 ): void {
-  const { arr } = resolveArrayTarget(op.operator, context.raw, path);
+  const { arr } = resolveArrayTarget(op.operator, context.raw, path, pathWriteOptions(context));
   if (arr === undefined) {
     return; // absent field — Mongo no-ops $pull / $pullAll
   }

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -140,13 +140,13 @@ export interface PathWriteOptions {
    * stays faithful to MongoDB (which throws "Cannot create field ... in element
    * {x: null}"); opt in via `update(..., { allowNullIntermediates: true })`.
    */
-  allowNullIntermediates?: boolean;
+  allowNullIntermediates: boolean;
 }
 
 export function ensureParentPath(
   target: object,
   path: string,
-  options: PathWriteOptions = {},
+  options: PathWriteOptions,
 ): { parent: any; key: string } {
   const parts = splitPath(path);
   // Fabricated branches match the document's flavor: a null-prototype document
@@ -188,7 +188,7 @@ export function setValueAtPath(
   target: object,
   path: string,
   value: unknown,
-  options: PathWriteOptions = {},
+  options: PathWriteOptions,
 ): void {
   const { parent, key } = ensureParentPath(target, path, options);
   if (Array.isArray(parent) && isArrayIndex(key)) {

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -129,7 +129,25 @@ export function resolveParentPath(
   return { parent: current, key: parts[parts.length - 1]! };
 }
 
-export function ensureParentPath(target: object, path: string): { parent: any; key: string } {
+/**
+ * Options shared by the path-*writing* helpers (`ensureParentPath`,
+ * `setValueAtPath`).
+ */
+export interface PathWriteOptions {
+  /**
+   * Treat a `null` intermediate the way an *absent* one is treated: overwrite it
+   * with a freshly-created branch rather than rejecting. Off by default so mill
+   * stays faithful to MongoDB (which throws "Cannot create field ... in element
+   * {x: null}"); opt in via `update(..., { allowNullIntermediates: true })`.
+   */
+  allowNullIntermediates?: boolean;
+}
+
+export function ensureParentPath(
+  target: object,
+  path: string,
+  options: PathWriteOptions = {},
+): { parent: any; key: string } {
   const parts = splitPath(path);
   // Fabricated branches match the document's flavor: a null-prototype document
   // grows null-prototype branches, a plain-object document grows plain ones.
@@ -139,7 +157,11 @@ export function ensureParentPath(target: object, path: string): { parent: any; k
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i]!;
     const existing = (current as any)[part];
-    if (existing === undefined) {
+    // A `null` intermediate is normally a hard error (Mongo can't create a
+    // field inside null); with `allowNullIntermediates` it's treated as absent
+    // and overwritten by the created branch.
+    const absent = existing === undefined || (options.allowNullIntermediates && existing === null);
+    if (absent) {
       // Absent intermediate — Mongo creates the missing branch as an object.
       // Growing an array through an out-of-bounds index pads the gap with null
       // (Mongo's behavior) rather than leaving sparse holes.
@@ -162,8 +184,13 @@ export function ensureParentPath(target: object, path: string): { parent: any; k
   return { parent: current, key: parts[parts.length - 1]! };
 }
 
-export function setValueAtPath(target: object, path: string, value: unknown): void {
-  const { parent, key } = ensureParentPath(target, path);
+export function setValueAtPath(
+  target: object,
+  path: string,
+  value: unknown,
+  options: PathWriteOptions = {},
+): void {
+  const { parent, key } = ensureParentPath(target, path, options);
   if (Array.isArray(parent) && isArrayIndex(key)) {
     // Writing past the end grows the array; Mongo pads the gap with null rather
     // than leaving holes. e.g. [1] + "scores.3" -> [1, null, null, 4].

--- a/packages/mill/tests/operators/allow-null-intermediates.test.ts
+++ b/packages/mill/tests/operators/allow-null-intermediates.test.ts
@@ -1,0 +1,98 @@
+import { createReactive, unwrap } from "@supergrain/kernel";
+import { describe, expect, it } from "vitest";
+
+import { update, type UpdateOperations } from "../../src";
+
+// `allowNullIntermediates` is a deliberate *departure* from MongoDB (real mongod
+// throws in every case below - see rejection-parity.test.ts),
+// so these tests can't go through the mongo-oracle
+// helpers. They use the raw `update` and verify the round-trip by hand: apply
+// with the option, assert the forward result, then apply the generated `undo`
+// and assert the store is byte-for-byte back to where it started — including the
+// original `null`s.
+function expectRoundTrip<T extends object>(
+  store: T,
+  ops: UpdateOperations<T>,
+  assertForward: () => void,
+): void {
+  const before = structuredClone(unwrap(store));
+  const { undo } = update(store, {}, ops, { allowNullIntermediates: true });
+  assertForward();
+  update(store, {}, undo);
+  expect(unwrap(store)).toEqual(before);
+}
+
+describe("allowNullIntermediates", () => {
+  it("$set builds an object over a null intermediate", () => {
+    const store = createReactive<any>({ attributes: { clipboard: null } });
+    expectRoundTrip(store, { $set: { "attributes.clipboard.card": "c1" } }, () => {
+      expect(store.attributes.clipboard).toEqual({ card: "c1" });
+    });
+  });
+
+  it("$set builds objects over several consecutive null intermediates", () => {
+    const store = createReactive<any>({ a: null });
+    expectRoundTrip(store, { $set: { "a.b.c.d": 1 } }, () => {
+      expect(store.a).toEqual({ b: { c: { d: 1 } } });
+    });
+  });
+
+  it("$push creates the array when the target is null", () => {
+    const store = createReactive<any>({ attributes: { cards: null } });
+    expectRoundTrip(store, { $push: { "attributes.cards": { id: "x" } } }, () => {
+      expect(store.attributes.cards).toEqual([{ id: "x" }]);
+    });
+  });
+
+  it("$push creates arrays through a null intermediate", () => {
+    const store = createReactive<any>({ attributes: null });
+    expectRoundTrip(store, { $push: { "attributes.cards": 1 } }, () => {
+      expect(store.attributes).toEqual({ cards: [1] });
+    });
+  });
+
+  it("$addToSet creates the array when the target is null", () => {
+    const store = createReactive<any>({ tags: null });
+    expectRoundTrip(store, { $addToSet: { tags: { $each: ["a", "a", "b"] } } }, () => {
+      expect(store.tags).toEqual(["a", "b"]);
+    });
+  });
+
+  it("$inc builds objects over a null intermediate", () => {
+    const store = createReactive<any>({ counters: null });
+    expectRoundTrip(store, { $inc: { "counters.hits": 5 } }, () => {
+      expect(store.counters).toEqual({ hits: 5 });
+    });
+  });
+
+  it("$pull / $pullAll / $pop no-op on a null target (leaving the null in place)", () => {
+    for (const ops of [
+      { $pull: { items: 1 } },
+      { $pullAll: { items: [1] } },
+      { $pop: { items: 1 } },
+    ] as Array<UpdateOperations<any>>) {
+      const store = createReactive<any>({ items: null });
+      const { undo } = update(store, {}, ops, { allowNullIntermediates: true });
+      expect(store.items).toBe(null);
+      expect(undo).toEqual({}); // a no-op contributes nothing to undo
+    }
+  });
+
+  it("still rejects a scalar (non-null) intermediate", () => {
+    const store = createReactive<any>({ a: 42 });
+    expect(() =>
+      update(store, {}, { $set: { "a.b": 1 } }, { allowNullIntermediates: true }),
+    ).toThrow(/Cannot create field/i);
+    expect(() =>
+      update(store, {}, { $push: { "a.b": 1 } }, { allowNullIntermediates: true }),
+    ).toThrow(/must point to an array/i);
+  });
+
+  it("is off by default: a null intermediate/target still throws like MongoDB", () => {
+    const setStore = createReactive<any>({ a: null });
+    expect(() => update(setStore, {}, { $set: { "a.b": 1 } })).toThrow(/Cannot create field/i);
+
+    const pushStore = createReactive<any>({ a: null });
+    expect(() => update(pushStore, {}, { $push: { a: 1 } })).toThrow(/must point to an array/i);
+  });
+});

--- a/packages/mill/tests/path.test.ts
+++ b/packages/mill/tests/path.test.ts
@@ -82,13 +82,15 @@ describe("deleteValueAtPath", () => {
 describe("setValueAtPath", () => {
   it("creates intermediate objects as needed", () => {
     const target: Record<string, unknown> = {};
-    setValueAtPath(target, "a.b.c", 1);
+    setValueAtPath(target, "a.b.c", 1, { allowNullIntermediates: false });
     expect(target).toEqual({ a: { b: { c: 1 } } });
   });
 
   it("rejects creating a field inside a non-container intermediate", () => {
     const target: Record<string, unknown> = { a: 5 };
-    expect(() => setValueAtPath(target, "a.b", 1)).toThrow(/cannot create field/i);
+    expect(() => setValueAtPath(target, "a.b", 1, { allowNullIntermediates: false })).toThrow(
+      /cannot create field/i,
+    );
     expect(target).toEqual({ a: 5 });
   });
 });

--- a/packages/mill/tests/rejection-parity.test.ts
+++ b/packages/mill/tests/rejection-parity.test.ts
@@ -17,12 +17,15 @@ interface RejectionCase {
 const cases: Array<RejectionCase> = [
   { name: "$push onto a number", doc: { a: 5 }, ops: { $push: { a: 1 } } },
   { name: "$push onto a string", doc: { a: "x" }, ops: { $push: { a: 1 } } },
+  { name: "$push onto null", doc: { a: null }, ops: { $push: { a: 1 } } },
+  { name: "$push within null", doc: { a: null }, ops: { $push: { "a.b": 1 } } },
   { name: "$inc on a string", doc: { a: "x" }, ops: { $inc: { a: 1 } } },
   { name: "$mul on a string", doc: { a: "x" }, ops: { $mul: { a: 2 } } },
   { name: "$pop on a number", doc: { a: 5 }, ops: { $pop: { a: 1 } } },
   { name: "$addToSet onto a number", doc: { a: 5 }, ops: { $addToSet: { a: 1 } } },
   { name: "$pull on a number", doc: { a: 5 }, ops: { $pull: { a: 1 } } },
   { name: "$pullAll on a number", doc: { a: 5 }, ops: { $pullAll: { a: [1] } } },
+  { name: "$set within null", doc: { a: null }, ops: { $set: { "a.b": "foo" } } },
 
   // Array operators whose path runs *through* a scalar intermediate: there is no
   // array to operate on and Mongo can't traverse the scalar.


### PR DESCRIPTION
When a MongoDB operation encounters an absent intermediate object on a path, it will create it as `{}` / `[]`. If it encounters a *null* path, it will instead error.

Our existing app expects both cases to create the object (due to the absent -> nil conversion performed by Ecto). To support that expectation while also maintaining MongoDB parity, this PR adds an option `allowNullIntermediates` to the `update` function, which turns on the null-as-absent behavior.