### PR TITLE
Add changeset: allowNullIntermediates option for mill

### DIFF
--- a/.changeset/mill-allow-null-intermediates.md
+++ b/.changeset/mill-allow-null-intermediates.md
@@ -1,0 +1,13 @@
+---
+"@supergrain/mill": minor
+---
+
+Add an `allowNullIntermediates` option to `update()`.
+
+By default mill stays faithful to MongoDB and rejects writing through a `null` (e.g. `$set`-ing `"a.b"` when `a` is `null` throws `Cannot create field 'b' in element {a: null}`). Pass `allowNullIntermediates: true` to instead treat a `null` intermediate or target as if the field were absent:
+
+- `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects over `null` intermediates.
+- `$push` / `$addToSet` create the array when the target (or an intermediate) is `null`.
+- `$pull` / `$pullAll` / `$pop` no-op on a `null` target, exactly as they do for a missing field.
+
+A present scalar in the way is still an error — only `null` is treated as absent — and the generated `undo` restores the prior `null` exactly.


### PR DESCRIPTION
Adds a changeset cutting a **7.1.0** minor release across the `@supergrain/*` fixed group.

## What's in the release
The only source change since 7.0.1: the new `allowNullIntermediates` option on mill's `update()` (#125).

- By default mill stays faithful to MongoDB and rejects writing through a `null`.
- `allowNullIntermediates: true` treats a `null` intermediate/target as if the field were absent (`$set`/`$inc`/`$mul`/`$min`/`$max`/`$rename` build objects; `$push`/`$addToSet` create arrays; `$pull`/`$pullAll`/`$pop` no-op). A present scalar is still an error; `undo` restores the prior `null`.

## Note on devtools
`@supergrain/devtools` was frozen on npm at 6.3.0 because it lacked an npm Trusted Publisher (OIDC) config. That's now been added, so merging the resulting `Release: Version Packages` PR will publish `@supergrain/devtools@7.1.0` alongside the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)