### PR TITLE
Review fixes for #136: remove the coverage ignore, add a changeset, harden the A/B tooling

### DIFF
--- a/.changeset/heavy-pugs-shave.md
+++ b/.changeset/heavy-pugs-shave.md
@@ -1,0 +1,27 @@
+---
+"@supergrain/kernel": minor
+---
+
+Faster list teardown and swap tracking in `@supergrain/kernel/react`.
+
+**`tracked()` now defers effect teardown past the next paint.** Unlinking an
+effect from the signal graph is bookkeeping with no observable output, so
+running it inside React's unmount commit put O(subscriptions) work between a
+state change and the frame that shows it — unmounting a 1,000-row list tore
+down 1,000 effects before the browser could present the empty table. Disposers
+are now queued and flushed in the first macrotask after the next frame.
+
+Every queued disposer still runs: the flush is deferred, never skipped, so
+subscriber lists cannot leak. The observable difference is a short window after
+unmount in which a component's effect can still fire; for `tracked()` that means
+a `forceUpdate` on an unmounted component, which React ignores. If you dispose
+effects yourself and need them to stop firing at exactly the unmount commit,
+guard the effect body with your own disposed flag.
+
+**Parent-mode `For` now uses a single array-level subscription for swaps.** A
+new internal `$ELEMENTS` signal answers "some element was replaced in place" for
+the whole array, replacing one subscription per index in the O(1)-swap effect.
+Rendering 10,000 rows no longer creates 10,000 per-index dependency links for
+swap tracking. Structural changes (push, splice, length, new array) are
+unaffected — they still notify through the version and ownKeys signals. No
+public API change; behavior is identical.

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,8 +63,14 @@ jobs:
           cp -R packages/js-krauset/dist /tmp/app-pr
 
       - name: Build benchmark app (base)
+        # Interpolated through env rather than straight into the script: `${{ }}`
+        # is pasted in as shell source, so a value carrying shell syntax would be
+        # executed. Nothing here is attacker-controlled today (both inputs need
+        # write access), but the quoted-env form removes the class outright.
+        env:
+          BASE_REF: ${{ github.base_ref || github.event.repository.default_branch }}
         run: |
-          BASE="origin/${{ github.base_ref || github.event.repository.default_branch }}"
+          BASE="origin/$BASE_REF"
           # Replace the build inputs outright so files this PR *added* don't
           # linger in the control build; the checkout restores the rest.
           rm -rf packages/kernel/src packages/js-krauset/src
@@ -103,15 +109,18 @@ jobs:
       - name: Run interleaved benchmark
         if: steps.kernel-diff.outputs.changed == 'true'
         working-directory: packages/js-krauset
+        env:
+          RUNS: ${{ github.event.inputs.runs || '10' }}
+          BASE_REF: ${{ github.base_ref || 'default' }}
         run: >
           node perf-ab.ts
           --mode app
           --control /tmp/app-base
           --experiment /tmp/app-pr
-          --runs ${{ github.event.inputs.runs || '10' }}
+          --runs "$RUNS"
           --out "$GITHUB_WORKSPACE/benchmark-report.md"
           --json "$GITHUB_WORKSPACE/benchmark-data.json"
-          --label-control "base (${{ github.base_ref || 'default' }})"
+          --label-control "base ($BASE_REF)"
           --label-experiment "PR"
 
       - name: Publish to job summary

--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,3 @@ es/
 # Claude Code
 .claude/settings.local.json
 .claude/worktrees/
-
-# Local Claude Code settings (machine-specific hook paths)
-.claude/settings.json

--- a/packages/js-krauset/perf-ab.ts
+++ b/packages/js-krauset/perf-ab.ts
@@ -29,6 +29,7 @@
  */
 import { execSync } from "child_process";
 import { cpSync, existsSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { resolve } from "path";
 
 // Explicit .ts extension: these root-level scripts run through Node's type
@@ -53,7 +54,16 @@ interface RunJson {
 
 function arg(name: string, fallback?: string): string {
   const i = process.argv.indexOf(`--${name}`);
-  if (i !== -1 && process.argv[i + 1]) return process.argv[i + 1];
+  if (i !== -1) {
+    // A flag with a missing or flag-shaped value is a typo, not a request for
+    // the default — silently substituting one would benchmark the wrong thing.
+    const value = process.argv[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      console.error(`--${name} requires a value`);
+      process.exit(1);
+    }
+    return value;
+  }
   if (fallback !== undefined) return fallback;
   console.error(`Missing required argument --${name}`);
   process.exit(1);
@@ -93,12 +103,41 @@ if (!Number.isInteger(runs) || runs < 1) {
 }
 
 const appDist = resolve(dir, "dist");
+const armTarget = mode === "kernel" ? kernelDist : appDist;
+
+// Swapping arms overwrites a real build output. Without restoring it, whatever
+// ran last silently *becomes* your `dist` — so a later `pnpm test` or a manual
+// check would be reading a foreign build with no indication anything happened.
+const backupDir = resolve(tmpdir(), `supergrain-perf-ab-${process.pid}`);
+const hadExistingDist = existsSync(armTarget);
+if (hadExistingDist) {
+  cpSync(armTarget, backupDir, { recursive: true });
+}
+
+let restored = false;
+function restoreDist(): void {
+  if (restored) return;
+  restored = true;
+  rmSync(armTarget, { recursive: true, force: true });
+  if (hadExistingDist) {
+    cpSync(backupDir, armTarget, { recursive: true });
+    rmSync(backupDir, { recursive: true, force: true });
+  }
+  console.log(`Restored ${armTarget} to its pre-run state.`);
+}
+
+process.on("exit", restoreDist);
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    restoreDist();
+    process.exit(1);
+  });
+}
 
 /** Swap in one arm: prebuilt kernel dist (kernel mode) or app bundle (app mode). */
 function useArm(from: string): void {
-  const target = mode === "kernel" ? kernelDist : appDist;
-  rmSync(target, { recursive: true, force: true });
-  cpSync(from, target, { recursive: true });
+  rmSync(armTarget, { recursive: true, force: true });
+  cpSync(from, armTarget, { recursive: true });
 }
 
 /**

--- a/packages/js-krauset/src/main.tsx
+++ b/packages/js-krauset/src/main.tsx
@@ -182,6 +182,11 @@ export const remove = (id: number) => {
 
 export const select = (itemOrId: RowData | number) => {
   const item = typeof itemOrId === "number" ? store.data.find((d) => d.id === itemOrId) : itemOrId;
+  // Re-selecting the current row writes nothing. (The old `store.selected = id`
+  // model no-op'd here too — `setProperty` skips unchanged writes — so this
+  // isn't new, just explicit.) It does mean a benchmark that times a click on
+  // an already-selected row measures nothing; perf.test.ts asserts the timed
+  // row isn't the warmed-up one to catch that.
   if (!item || (selectedRow && selectedRow.id === item.id)) {
     return;
   }

--- a/packages/js-krauset/src/perf.test.ts
+++ b/packages/js-krauset/src/perf.test.ts
@@ -268,6 +268,13 @@ describe("performance benchmarks", () => {
     await click(page, "#run");
     await waitFor(page, "tbody>tr:nth-of-type(1000)");
     await click(page, "tbody>tr:nth-of-type(5)>td:nth-of-type(2)>a");
+    // Selecting an already-selected row is a no-op, so timing one would report
+    // "0ms" for doing nothing. Assert the warmup left a *different* row
+    // selected, otherwise this benchmark silently stops measuring anything.
+    const warmupSelectedTimedRow = await page.evaluate(() =>
+      document.querySelector("tbody>tr:nth-of-type(2)")?.classList.contains("danger"),
+    );
+    expect(warmupSelectedTimedRow).toBe(false);
     const ms = await timeClick(page, "tbody>tr:nth-of-type(2)>td:nth-of-type(2)>a", {
       traceName: "select-row",
       cpuThrottle: 4,

--- a/packages/kernel/src/react/disposal-queue.ts
+++ b/packages/kernel/src/react/disposal-queue.ts
@@ -16,10 +16,21 @@
  * unmounted component is a no-op in React.
  */
 
+// How long to wait before flushing without a frame. Only reached when rAF
+// never fires (hidden document) or doesn't exist — see scheduleFlush.
+const BACKSTOP_MS = 100;
+
 let queue: Array<() => void> = [];
 let scheduled = false;
 
 function flush(): void {
+  // A round arms two timers (see scheduleFlush) and the loser fires later with
+  // nothing left to do. Returning *before* clearing `scheduled` is the point:
+  // clearing it here would strand the timers a subsequent round had already
+  // armed, and the next scheduleDisposal would arm a third set on top.
+  if (queue.length === 0) {
+    return;
+  }
   scheduled = false;
   const disposers = queue;
   queue = [];
@@ -40,24 +51,24 @@ function flush(): void {
   }
 }
 
-/* c8 ignore start -- rAF branch is browser-only; jsdom exercises the fallback */
 function scheduleFlush(): void {
   // requestAnimationFrame fires just before the frame is presented; the nested
   // setTimeout then lands in the first macrotask after it. The plain setTimeout
-  // is a backstop for environments without rAF (SSR/tests) and for hidden
-  // documents, where rAF callbacks are suspended indefinitely.
+  // is a backstop for environments without rAF (SSR/node tests) and for hidden
+  // documents, where rAF callbacks are suspended indefinitely. Both branches are
+  // exercised: tests/react covers the rAF path in a real browser,
+  // tests/core covers the fallback under node.
   if (typeof requestAnimationFrame === "function") {
     requestAnimationFrame(() => setTimeout(flush, 0));
-    setTimeout(flush, 100);
+    setTimeout(flush, BACKSTOP_MS);
   } else {
     setTimeout(flush, 0);
   }
 }
-/* c8 ignore stop */
 
 /**
  * Queue an effect disposer to run off the paint-critical path — normally in
- * the first macrotask after the next paint, but the 100ms backstop (hidden
+ * the first macrotask after the next paint, but the backstop (hidden
  * documents, environments without rAF) may fire without any paint occurring.
  * The guarantee is "deferred, always runs", not "a paint happened first".
  */

--- a/packages/kernel/tests/react/disposal-queue-browser.test.tsx
+++ b/packages/kernel/tests/react/disposal-queue-browser.test.tsx
@@ -1,0 +1,108 @@
+// Browser-environment tests for the deferred disposal queue.
+//
+// The node suite (tests/core/disposal-queue.test.ts) drives the plain-setTimeout
+// fallback with fake timers. This file covers the branch that actually ships to
+// users: a real requestAnimationFrame, its nested macrotask, and the backstop
+// timer that outlives an already-drained round. Between the two files
+// `scheduleFlush` needs no coverage ignore.
+import type { ReactiveNode } from "alien-signals/system";
+
+import { createReactive } from "@supergrain/kernel";
+import { getActiveSub } from "@supergrain/kernel/internal";
+import { tracked } from "@supergrain/kernel/react";
+import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+
+import { scheduleDisposal } from "../../src/react/disposal-queue";
+
+afterEach(() => cleanup());
+
+/**
+ * Resolve in the first macrotask after the next frame — the exact slot
+ * `scheduleFlush` targets. Our rAF callback was registered first, so its nested
+ * `setTimeout(flush, 0)` is queued ahead of this one and the flush has already
+ * run by the time this resolves.
+ */
+function afterNextFrame(): Promise<void> {
+  return new Promise<void>((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(predicate: () => boolean, timeout = 2000): Promise<void> {
+  const start = performance.now();
+  while (!predicate()) {
+    if (performance.now() - start > timeout) {
+      throw new Error(`Timed out after ${timeout}ms waiting for condition`);
+    }
+    await sleep(10);
+  }
+}
+
+describe("scheduleDisposal (browser / requestAnimationFrame path)", () => {
+  it("does not run the disposer synchronously, then flushes after the next frame", async () => {
+    const ran: Array<string> = [];
+
+    scheduleDisposal(() => ran.push("a"));
+    scheduleDisposal(() => ran.push("b"));
+    expect(ran).toEqual([]);
+
+    await afterNextFrame();
+    expect(ran).toEqual(["a", "b"]);
+  });
+
+  it("ignores the backstop timer left over from an already-drained round", async () => {
+    const ran: Array<string> = [];
+
+    scheduleDisposal(() => ran.push("first"));
+    await afterNextFrame();
+    expect(ran).toEqual(["first"]);
+
+    // The round above also armed a ~100ms backstop, which is still pending.
+    // Let it fire on an empty queue: it must neither re-run "first" nor clear
+    // the scheduled flag out from under a later round.
+    await sleep(200);
+    expect(ran).toEqual(["first"]);
+
+    // A disposer queued after that stale timer still flushes exactly once.
+    scheduleDisposal(() => ran.push("second"));
+    await afterNextFrame();
+    expect(ran).toEqual(["first", "second"]);
+  });
+
+  // Throw-during-drain is covered in tests/core, where fake timers make the
+  // rethrow synchronously catchable. Reproducing it here would only leave an
+  // uncaught error in the browser run.
+});
+
+describe("tracked() teardown", () => {
+  it("unlinks the component's effect from the signal graph after unmount", async () => {
+    const store = createReactive({ value: 0 });
+    let effectNode: ReactiveNode | undefined;
+
+    const Probe = tracked(() => {
+      // tracked() points activeSub at this component's effect node before
+      // calling the component, so this captures the node whose disposal we
+      // want to observe. `deps` is the alien-signals dependency list: non-empty
+      // while linked, cleared on dispose.
+      effectNode = getActiveSub();
+      return <span>{store.value}</span>;
+    });
+
+    const { unmount } = render(<Probe />);
+    expect(effectNode?.deps).toBeTruthy();
+
+    unmount();
+    // Teardown is deferred — by useDisposeOnUnmount's StrictMode timer in dev
+    // and by the disposal queue in every build — so the graph link outlives the
+    // unmount commit.
+    expect(effectNode?.deps).toBeTruthy();
+
+    // ...but it always runs. "Deferred, never skipped" is what keeps subscriber
+    // lists from leaking.
+    await waitUntil(() => !effectNode?.deps);
+    expect(effectNode?.deps).toBeFalsy();
+  });
+});


### PR DESCRIPTION
Targets #136's branch, so merging this folds the fixes into that PR rather than opening a competing one. One commit on top of `104f9af`.

## The coverage ignore

`disposal-queue.ts` carried `/* c8 ignore start -- rAF branch is browser-only */` around `scheduleFlush`. That hid the branch that actually ships to users: the node suite only ever drove the `setTimeout` fallback, so the `requestAnimationFrame` path had neither a test nor coverage.

Both branches are now covered for real:

- `tests/core/disposal-queue.test.ts` (node) keeps driving the fallback with fake timers.
- `tests/react/disposal-queue-browser.test.tsx` (new, real browser) exercises the rAF callback, its nested macrotask, and the backstop timer.

`disposal-queue.ts` reports 100% statements/branches/functions/lines with `skipped: 0` — no ignores, all 10 branches hit.

The other `c8 ignore`s in the kernel (`for.ts` SSR, `use-dispose-on-unmount.ts` production branch, `write.ts`, `read.ts`) predate #136 and are untouched here. The `use-dispose-on-unmount` one is the interesting leftover — it guards a branch selected by build-time env replacement, so covering it needs a production-env test run rather than a new test.

## Stale-backstop fix

Found while covering the rAF path. Each round arms two timers — an rAF chain and a ~100 ms backstop — and the loser fires later with an empty queue. It used to clear `scheduled` anyway, stranding the timers a subsequent round had already armed and making the next `scheduleDisposal` arm a third set on top.

`flush()` now returns *before* touching `scheduled` when there's nothing to drain. Every disposer still runs; this only stops the redundant re-arming. Covered by the new browser test, which waits past the backstop deadline and asserts a later round still flushes exactly once.

## `tracked()` teardown integration test

The queue was tested in isolation; its only caller was not. New test captures the component's effect node during render and asserts the graph link survives the unmount commit and is always cleared afterwards — "deferred, never skipped", which is what keeps subscriber lists from leaking.

## Changeset

#136 changes published behavior — `tracked()` defers effect teardown past paint, and parent-mode `For` swaps track one array-level signal instead of one per index — but carried no changeset, so merging would have bumped nothing. D5 (refreshing the official js-framework-benchmark submission) needs a kernel publish. Added as a minor, with the deferred-teardown caveat spelled out for consumers who dispose effects themselves.

## Smaller items

- **`benchmark.yml`** — `runs` and `base_ref` now go through `env:` instead of being pasted into shell source as `${{ }}`. Both need write access to influence today, so this closes the class rather than fixing a live hole.
- **`perf-ab.ts`** — restores `packages/kernel/dist` (or `js-krauset/dist`) on exit, including on throw and SIGINT. Swapping arms overwrote a real build output and left whichever arm ran last silently standing in as your `dist`. Verified by interrupting a run and confirming the original contents come back. Also rejects a flag whose value is missing or flag-shaped instead of substituting the default and benchmarking the wrong thing.
- **`perf.test.ts`** — asserts the select benchmark's warmup left a *different* row selected. Re-selecting the current row is a no-op (true under the old `store.selected` model too, since `setProperty` skips unchanged writes), so timing a click on an already-selected row would report ~0 ms for doing nothing. This guards the number, not the app.
- **`.gitignore`** — stopped ignoring `.claude/settings.json`. `settings.local.json` is already ignored and is where machine-specific hook paths belong; ignoring the shared file blocks committing project-wide settings. Easy to revert if the intent was to keep that file local.

## Verification

All five checks from `CLAUDE.md` pass locally: `pnpm test` (1062 passed, 81 files), `test:validate`, `typecheck`, `lint`, `format`. Coverage total stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAbdFjd8xbca2ptYvP5BZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAbdFjd8xbca2ptYvP5BZX)_