### PR TITLE
fix(mill): Prevent undo ops at conflicting paths

### DIFF
--- a/.changeset/nervous-donkeys-jam.md
+++ b/.changeset/nervous-donkeys-jam.md
@@ -1,0 +1,13 @@
+---
+"@supergrain/mill": patch
+---
+
+Fix `update()` generating an unreplayable `undo` when several paths write under a
+branch the update itself has to create.
+
+`{ $set: { "rel.course": …, "rel.planbook": … } }` on a document with no `rel`
+captured `$unset: { rel: "" }` for the first path — which creates `rel` — and then
+`$unset: { "rel.planbook": "" }` for the second, which now finds it. Replaying that
+undo threw `Update would create a conflict between paths "rel" and "rel.planbook"`.
+The shallower entry already restores the whole subtree, so entries an existing one
+covers are no longer recorded.

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -20,6 +20,7 @@ import {
   type ArrayPushOperations,
   type ArrayWriteOperations,
   type NumericPathOperations,
+  pathsConflict,
   type SetPathOperations,
   type UnsetPathOperations,
 } from "./path";
@@ -168,24 +169,6 @@ function referencedArrayFilterIdentifiers(operations: UpdateOperations<any>): Se
     }
   }
   return used;
-}
-
-// Two update paths conflict when they're equal or one is a prefix of the other
-// (compared segment by segment) — MongoDB rejects such an update rather than
-// applying both. e.g. "a" conflicts with "a" and "a.b"; "a.b" and "a.c" don't.
-function pathsConflict(a: string, b: string): boolean {
-  if (a === b) {
-    return true;
-  }
-  const aSegments = a.split(".");
-  const bSegments = b.split(".");
-  const shared = Math.min(aSegments.length, bSegments.length);
-  for (let i = 0; i < shared; i++) {
-    if (aSegments[i] !== bSegments[i]) {
-      return false;
-    }
-  }
-  return true; // one path is a prefix of the other
 }
 
 // Reject an update whose operators (or keys) write the same path, or a

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -107,6 +107,32 @@ export function splitPath(path: string): Array<PathSegment> {
   return parts;
 }
 
+/**
+ * Whether `ancestor` covers `path` — they're equal, or `ancestor` names a
+ * segment-wise prefix of `path`, so writing `ancestor` also writes everything
+ * `path` names. e.g. "a" covers "a" and "a.b"; "a.b" covers neither "a" nor
+ * "a.c". Directional: `pathCovers("a.b", "a")` is false.
+ */
+export function pathCovers(ancestor: string, path: string): boolean {
+  // A segment-wise prefix is exactly a string prefix that lands on a separator:
+  // `path` covered by `ancestor` means `path` is `ancestor` + "." + the rest, and
+  // splitting that always reproduces `ancestor`'s segments first. The boundary
+  // check is what keeps "a" from covering "ab". Done on the raw strings so this
+  // stays allocation-free — it runs against every recorded undo entry.
+  return (
+    path.startsWith(ancestor) && (path.length === ancestor.length || path[ancestor.length] === ".")
+  );
+}
+
+/**
+ * Two update paths conflict when either covers the other — MongoDB rejects such
+ * an update rather than applying both. e.g. "a" conflicts with "a" and "a.b";
+ * "a.b" and "a.c" don't.
+ */
+export function pathsConflict(a: string, b: string): boolean {
+  return pathCovers(a, b) || pathCovers(b, a);
+}
+
 export function resolveParentPath(
   target: object,
   path: string,

--- a/packages/mill/src/undo.ts
+++ b/packages/mill/src/undo.ts
@@ -1,4 +1,4 @@
-import { isArrayIndex, splitPath } from "./path";
+import { isArrayIndex, pathCovers, splitPath } from "./path";
 import { cloneValue, isContainer } from "./util";
 
 // ─── undo accumulation ──────────────────────────────────────────────────────
@@ -16,19 +16,38 @@ export interface MutableUndo {
   $pop?: Record<string, 1 | -1>;
 }
 
+/**
+ * Don't record undo ops for ops that will already be undone by an op at an
+ * ancestor path. Otherwise we get a conflict.
+ */
+function coveredByExistingEntry(undo: MutableUndo, path: string): boolean {
+  for (const existingOps of Object.values(undo)) {
+    for (const existingOpPath of Object.keys(existingOps as Record<string, unknown>)) {
+      if (pathCovers(existingOpPath, path)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function undoSet(undo: MutableUndo, path: string, value: unknown): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$set ??= {})[path] = value;
 }
 
 export function undoUnset(undo: MutableUndo, path: string): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$unset ??= {})[path] = "";
 }
 
 export function undoPushSpec(undo: MutableUndo, path: string, spec: unknown): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$push ??= {})[path] = spec;
 }
 
 export function undoPop(undo: MutableUndo, path: string, direction: 1 | -1): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$pop ??= {})[path] = direction;
 }
 

--- a/packages/mill/tests/undo.test.ts
+++ b/packages/mill/tests/undo.test.ts
@@ -153,3 +153,56 @@ describe("undo — no-ops produce no undo", () => {
     expect(undo).toEqual({});
   });
 });
+
+// The undo document must itself be a legal update document. When several paths
+// share a branch the update has to create, the first one captures the whole
+// missing branch and the rest are redundant — emitting them anyway produced an
+// undo that `update()` refused to replay ("would create a conflict between
+// paths ...").
+describe("undo — sibling writes under a created branch stay conflict-free", () => {
+  it("collapses to the created branch for two $set siblings", () => {
+    const { undo } = roundTrip({} as Record<string, unknown>, {
+      $set: { "rel.course": { id: "c1" }, "rel.planbook": { id: "p1" } },
+    });
+    expect(undo).toEqual({ $unset: { rel: "" } });
+  });
+
+  it("collapses across a deeper shared branch", () => {
+    const { undo } = roundTrip({ a: {} } as Record<string, unknown>, {
+      $set: { "a.b.c": 1, "a.b.d": 2 },
+    });
+    expect(undo).toEqual({ $unset: { "a.b": "" } });
+  });
+
+  it("collapses across different operators", () => {
+    const { undo } = roundTrip({} as Record<string, unknown>, {
+      $set: { "rel.course": { id: "c1" } },
+      $inc: { "rel.count": 2 },
+      $push: { "rel.tags": "x" },
+    });
+    expect(undo).toEqual({ $unset: { rel: "" } });
+  });
+
+  it("keeps siblings that do not share a created branch", () => {
+    const { undo } = roundTrip({ rel: {} } as Record<string, unknown>, {
+      $set: { "rel.course": { id: "c1" }, "rel.planbook": { id: "p1" } },
+    });
+    expect(undo).toEqual({ $unset: { "rel.course": "", "rel.planbook": "" } });
+  });
+
+  it("collapses to a null intermediate under allowNullIntermediates", () => {
+    const initial = { rel: null } as Record<string, unknown>;
+    const store = createReactive(structuredClone(initial));
+
+    const { undo } = update(
+      store,
+      {},
+      { $set: { "rel.course": { id: "c1" }, "rel.planbook": { id: "p1" } } },
+      { allowNullIntermediates: true },
+    );
+    expect(undo).toEqual({ $set: { rel: null } });
+
+    update(store, {}, undo, { allowNullIntermediates: true });
+    expect(unwrap(store)).toEqual(initial);
+  });
+});


### PR DESCRIPTION
If you have operations with the same ancestor and `allowNullIntermediates` is true, then the first operation can (implicitly) create the ancestor. E.g., suppose `relationships` starts null below:
```
      .set("relationships.course.data", {
        id: payload.course.id,
        type: "course",
      })
      .set("relationships.planbook.data", {
        id: payload.planbook.id,
        type: "planbook",
      })
```
This then creates a conflict between the first operation's ancestor set and the second's sub-path set. The conflict is ignored when applying (as part of how `allowNullIntermediates` works), but it generates a real conflict in the undo patch.

This PR is an attempt to filter out conflicting ops in undo patches. In the above example, we would skip making an unset op for the second op, because we already restore the whole of `relationships` to null.

However, I'm not sure whether the logic makes sense for array operations (push to the end of an array, then set within a *different* element of the array -> will the first op's path make us incorrectly ignore the second op?).