### PR TITLE
fix(mill): plan the cheapest sufficient undo snapshot per path

### DIFF
--- a/.changeset/nervous-donkeys-jam.md
+++ b/.changeset/nervous-donkeys-jam.md
@@ -1,0 +1,13 @@
+---
+"@supergrain/mill": patch
+---
+
+Fix `update()` generating an unreplayable `undo` when several paths write under a
+branch the update itself has to create.
+
+`{ $set: { "rel.course": …, "rel.planbook": … } }` on a document with no `rel`
+captured `$unset: { rel: "" }` for the first path — which creates `rel` — and then
+`$unset: { "rel.planbook": "" }` for the second, which now finds it. Replaying that
+undo threw `Update would create a conflict between paths "rel" and "rel.planbook"`.
+The shallower entry already restores the whole subtree, so entries an existing one
+covers are no longer recorded.

--- a/.changeset/nervous-donkeys-jam.md
+++ b/.changeset/nervous-donkeys-jam.md
@@ -2,12 +2,23 @@
 "@supergrain/mill": patch
 ---
 
-Fix `update()` generating an unreplayable `undo` when several paths write under a
-branch the update itself has to create.
+Fix `update()` generating an unreplayable `undo` when one path's inverse covers
+another's — replaying it threw `Update would create a conflict between paths
+"…" and "…"`. Two shapes were affected:
 
-`{ $set: { "rel.course": …, "rel.planbook": … } }` on a document with no `rel`
-captured `$unset: { rel: "" }` for the first path — which creates `rel` — and then
-`$unset: { "rel.planbook": "" }` for the second, which now finds it. Replaying that
-undo threw `Update would create a conflict between paths "rel" and "rel.planbook"`.
-The shallower entry already restores the whole subtree, so entries an existing one
-covers are no longer recorded.
+- Several paths writing under a branch the update itself creates
+  (`{ $set: { "rel.course": …, "rel.planbook": … } }` with no `rel`): the first
+  path's undo restores the whole missing branch, so later entries under it are
+  redundant and are no longer recorded.
+- Index writes on one array both in and out of bounds
+  (`{ $set: { "arr.2": …, "arr.5": … } }` on a 3-element array): the
+  out-of-bounds write's whole-array restore now absorbs the entries already
+  recorded beneath it — reconstructing the pristine array — instead of
+  conflicting with them. A granular array inverse whose path runs through an
+  ancestor array is recorded as that array's whole restore, so absorption
+  always suffices.
+
+Also fixes a MongoDB divergence: `$set` through a non-index field on an array
+(`{ $set: { "b.c": 1 } }` where `b` is an array) now throws
+`Cannot create field 'c' in element {b: […]}.` like real MongoDB, instead of
+setting a string key on the array.

--- a/.changeset/nervous-donkeys-jam.md
+++ b/.changeset/nervous-donkeys-jam.md
@@ -9,12 +9,15 @@ update itself creates (`{ $set: { "rel.course": …, "rel.planbook": … } }` wi
 no `rel`) and index writes on one array both in and out of bounds.
 
 Undo is no longer recorded op by op while the update runs. `update()` now
-copies the top-level fields its paths touch, applies the update, and derives
-the undo by comparing the result against the copies — one walk that either
-descends or emits at each spot, so conflicting undo paths cannot be produced.
-Some undo documents get finer as a result (growing an array now undoes with a
-truncation instead of restoring the whole prior array, and edits to arrays
-nested inside arrays restore precisely).
+plans, from the update document and the untouched document, the cheapest saved
+state that suffices per path — the value a write overwrites, an absence marker
+for a created branch, or just an array's length for appends and past-the-end
+growth — applies the update, and derives the undo by comparing each saved spot
+against the result. All planning happens before any mutation, and spots are
+kept non-nested, so conflicting undo paths cannot be produced. Appending to an
+array of any size plans O(1) undo work, and some undo documents get finer
+(growing an array now undoes with a truncation instead of restoring the whole
+prior array; edits to arrays nested inside arrays restore precisely).
 
 Also fixes a MongoDB divergence: `$set` through a non-index field on an array
 (`{ $set: { "b.c": 1 } }` where `b` is an array) now throws

--- a/.changeset/nervous-donkeys-jam.md
+++ b/.changeset/nervous-donkeys-jam.md
@@ -2,21 +2,19 @@
 "@supergrain/mill": patch
 ---
 
-Fix `update()` generating an unreplayable `undo` when one path's inverse covers
-another's — replaying it threw `Update would create a conflict between paths
-"…" and "…"`. Two shapes were affected:
+Fix `update()` generating an unreplayable `undo` when one path's inverse
+covered another's — replaying it threw `Update would create a conflict between
+paths "…" and "…"`. This hit updates writing several paths under a branch the
+update itself creates (`{ $set: { "rel.course": …, "rel.planbook": … } }` with
+no `rel`) and index writes on one array both in and out of bounds.
 
-- Several paths writing under a branch the update itself creates
-  (`{ $set: { "rel.course": …, "rel.planbook": … } }` with no `rel`): the first
-  path's undo restores the whole missing branch, so later entries under it are
-  redundant and are no longer recorded.
-- Index writes on one array both in and out of bounds
-  (`{ $set: { "arr.2": …, "arr.5": … } }` on a 3-element array): the
-  out-of-bounds write's whole-array restore now absorbs the entries already
-  recorded beneath it — reconstructing the pristine array — instead of
-  conflicting with them. A granular array inverse whose path runs through an
-  ancestor array is recorded as that array's whole restore, so absorption
-  always suffices.
+Undo is no longer recorded op by op while the update runs. `update()` now
+copies the top-level fields its paths touch, applies the update, and derives
+the undo by comparing the result against the copies — one walk that either
+descends or emits at each spot, so conflicting undo paths cannot be produced.
+Some undo documents get finer as a result (growing an array now undoes with a
+truncation instead of restoring the whole prior array, and edits to arrays
+nested inside arrays restore precisely).
 
 Also fixes a MongoDB divergence: `$set` through a non-index field on an array
 (`{ $set: { "b.c": 1 } }` where `b` is an array) now throws

--- a/packages/mill/README.md
+++ b/packages/mill/README.md
@@ -142,7 +142,7 @@ The query supports the standard Mongo query operators used to select an element:
 
 - A no-op operation contributes nothing to `undo`.
 - Previous state is restored exactly, including missing-vs-present: a field that was absent is `$unset`, a field that was present is `$set` back.
-- Array inverses use Mongo array operators where one suffices — an append undoes with `$pop`/`$slice`, a `$pop` with `$push`, a contiguous `$pull` with `$push` (`$each`/`$position`). An edit no single array operator can invert (a scattered `$pull`, or an op on an array nested inside another array) falls back to `$set`-ing the prior array.
+- Array inverses use Mongo array operators where one suffices — an append undoes with `$pop`/`$slice`, a `$pop` with `$push`, a contiguous `$pull` with `$push` (`$each`/`$position`). An edit no single array operator can invert (a scattered `$pull`) falls back to `$set`-ing the prior array.
 
 ```ts
 const { undo } = update(doc, {}, { $push: { items: "x" }, $inc: { count: 1 } });

--- a/packages/mill/README.md
+++ b/packages/mill/README.md
@@ -142,7 +142,7 @@ The query supports the standard Mongo query operators used to select an element:
 
 - A no-op operation contributes nothing to `undo`.
 - Previous state is restored exactly, including missing-vs-present: a field that was absent is `$unset`, a field that was present is `$set` back.
-- Array inverses use Mongo array operators where one suffices — an append undoes with `$pop`/`$slice`, a `$pop` with `$push`, a contiguous `$pull` with `$push` (`$each`/`$position`). An edit no single array operator can invert (a scattered `$pull`) falls back to `$set`-ing the prior array.
+- Array inverses use Mongo array operators where one suffices — an append undoes with `$pop`/`$slice`, a `$pop` with `$push`, a contiguous `$pull` with `$push` (`$each`/`$position`). An edit no single array operator can invert (a scattered `$pull`, or an op on an array nested inside another array) falls back to `$set`-ing the prior array.
 
 ```ts
 const { undo } = update(doc, {}, { $push: { items: "x" }, $inc: { count: 1 } });

--- a/packages/mill/src/array-ops.ts
+++ b/packages/mill/src/array-ops.ts
@@ -117,15 +117,6 @@ export function removeIndices(arr: Array<any>, shouldRemove: (index: number) => 
   setProperty(arr, "length", writeIndex);
 }
 
-export function isContiguousAscending(indices: Array<number>): boolean {
-  for (let i = 1; i < indices.length; i++) {
-    if (indices[i] !== indices[i - 1]! + 1) {
-      return false;
-    }
-  }
-  return true;
-}
-
 function compareScalar(a: any, b: any): number {
   if (a < b) return -1;
   if (a > b) return 1;

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -25,7 +25,7 @@ import {
   type UnsetPathOperations,
 } from "./path";
 import { type ArrayFilter, arrayFilterIdentifier, type Query } from "./query";
-import { type MutableUndo } from "./undo";
+import { buildUndoDocument, createUndo } from "./undo";
 
 /**
  * MongoDB-style update engine for in-memory documents.
@@ -221,7 +221,7 @@ export function update<T extends object>(
   options?: UpdateOptions,
 ): UpdateResult<T> {
   const raw = unwrap(doc) as object;
-  const undo: MutableUndo = {};
+  const undo = createUndo();
   const arrayFilters = options?.arrayFilters ?? [];
 
   assertNoPathConflicts(operations);
@@ -265,5 +265,5 @@ export function update<T extends object>(
     }
   });
 
-  return { doc, undo: undo as UpdateOperations<T> };
+  return { doc, undo: buildUndoDocument(undo) as UpdateOperations<T> };
 }

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -25,7 +25,7 @@ import {
   type UnsetPathOperations,
 } from "./path";
 import { type ArrayFilter, arrayFilterIdentifier, type Query } from "./query";
-import { buildUndoDocument, createUndo } from "./undo";
+import { buildUndo, captureOriginals } from "./undo";
 
 /**
  * MongoDB-style update engine for in-memory documents.
@@ -35,7 +35,7 @@ import { buildUndoDocument, createUndo } from "./undo";
  * and an `undo` — itself a standard Mongo update document — that reverses the
  * exact changes made. There is no mill-specific syntax.
  *
- * The implementation is split by concern: `undo.ts` (inverse accumulation),
+ * The implementation is split by concern: `undo.ts` (undo via snapshot + compare),
  * `array-ops.ts` (in-place array primitives), `query.ts` (positional resolution
  * + matching), `path.ts` (path navigation + typing), and one file per operator
  * under `operators/` over a small shared `operators/shared.ts`. This module just
@@ -221,7 +221,6 @@ export function update<T extends object>(
   options?: UpdateOptions,
 ): UpdateResult<T> {
   const raw = unwrap(doc) as object;
-  const undo = createUndo();
   const arrayFilters = options?.arrayFilters ?? [];
 
   assertNoPathConflicts(operations);
@@ -248,9 +247,10 @@ export function update<T extends object>(
     }
   }
 
+  const originals = captureOriginals(raw, operations as Record<string, object>);
+
   const context: OperatorContext = {
     raw,
-    undo,
     query: query as Query,
     arrayFilters,
     allowNullIntermediates: options?.allowNullIntermediates ?? false,
@@ -265,5 +265,5 @@ export function update<T extends object>(
     }
   });
 
-  return { doc, undo: buildUndoDocument(undo) as UpdateOperations<T> };
+  return { doc, undo: buildUndo(raw, originals) as UpdateOperations<T> };
 }

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -20,6 +20,7 @@ import {
   type ArrayPushOperations,
   type ArrayWriteOperations,
   type NumericPathOperations,
+  pathsConflict,
   type SetPathOperations,
   type UnsetPathOperations,
 } from "./path";
@@ -168,24 +169,6 @@ function referencedArrayFilterIdentifiers(operations: UpdateOperations<any>): Se
     }
   }
   return used;
-}
-
-// Two update paths conflict when they're equal or one is a prefix of the other
-// (compared segment by segment) — MongoDB rejects such an update rather than
-// applying both. e.g. "a" conflicts with "a" and "a.b"; "a.b" and "a.c" don't.
-function pathsConflict(a: string, b: string): boolean {
-  if (a === b) {
-    return true;
-  }
-  const aSegments = a.split(".");
-  const bSegments = b.split(".");
-  const shared = Math.min(aSegments.length, bSegments.length);
-  for (let i = 0; i < shared; i++) {
-    if (aSegments[i] !== bSegments[i]) {
-      return false;
-    }
-  }
-  return true; // one path is a prefix of the other
 }
 
 // Reject an update whose operators (or keys) write the same path, or a

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -25,7 +25,7 @@ import {
   type UnsetPathOperations,
 } from "./path";
 import { type ArrayFilter, arrayFilterIdentifier, type Query } from "./query";
-import { buildUndo, captureOriginals } from "./undo";
+import { buildUndo, planUndo } from "./undo";
 
 /**
  * MongoDB-style update engine for in-memory documents.
@@ -247,7 +247,7 @@ export function update<T extends object>(
     }
   }
 
-  const originals = captureOriginals(raw, operations as Record<string, object>);
+  const plan = planUndo(raw, operations as Record<string, object>);
 
   const context: OperatorContext = {
     raw,
@@ -265,5 +265,5 @@ export function update<T extends object>(
     }
   });
 
-  return { doc, undo: buildUndo(raw, originals) as UpdateOperations<T> };
+  return { doc, undo: buildUndo(raw, plan) as UpdateOperations<T> };
 }

--- a/packages/mill/src/operators/add-to-set.ts
+++ b/packages/mill/src/operators/add-to-set.ts
@@ -36,7 +36,10 @@ export function $addToSet(context: OperatorContext, operations: Record<string, a
     }
 
     const previousLength = target.arr.length;
+    undoTruncate(context.undo, context.raw, path, {
+      length: previousLength,
+      count: newItems.length,
+    });
     pushToArray(target.arr, newItems);
-    undoTruncate(context.undo, path, { length: previousLength, count: newItems.length });
   });
 }

--- a/packages/mill/src/operators/add-to-set.ts
+++ b/packages/mill/src/operators/add-to-set.ts
@@ -1,8 +1,8 @@
 import { pushToArray, resolveArrayTarget } from "../array-ops";
 import { setValueAtPath } from "../path";
-import { capturePathUndo, undoTruncate } from "../undo";
+import { capturePathUndo } from "../undo";
 import { isEqual, isObject } from "../util";
-import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions, recordTruncate } from "./shared";
 
 function uniqueAdditions(existing: ReadonlyArray<unknown>, candidates: Array<unknown>): Array<any> {
   const additions: Array<any> = [];
@@ -36,10 +36,7 @@ export function $addToSet(context: OperatorContext, operations: Record<string, a
     }
 
     const previousLength = target.arr.length;
-    undoTruncate(context.undo, context.raw, path, {
-      length: previousLength,
-      count: newItems.length,
-    });
+    recordTruncate(context, path, { length: previousLength, count: newItems.length });
     pushToArray(target.arr, newItems);
   });
 }

--- a/packages/mill/src/operators/add-to-set.ts
+++ b/packages/mill/src/operators/add-to-set.ts
@@ -1,8 +1,7 @@
 import { pushToArray, resolveArrayTarget } from "../array-ops";
 import { setValueAtPath } from "../path";
-import { capturePathUndo } from "../undo";
 import { isEqual, isObject } from "../util";
-import { eachPath, type OperatorContext, pathWriteOptions, recordTruncate } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 function uniqueAdditions(existing: ReadonlyArray<unknown>, candidates: Array<unknown>): Array<any> {
   const additions: Array<any> = [];
@@ -25,7 +24,6 @@ export function $addToSet(context: OperatorContext, operations: Record<string, a
 
     if (target.arr === undefined) {
       // Absent field — Mongo creates the array with the de-duplicated values.
-      capturePathUndo(context.undo, context.raw, path);
       setValueAtPath(context.raw, path, uniqueAdditions([], candidates), pathWriteOptions(context));
       return;
     }
@@ -35,8 +33,6 @@ export function $addToSet(context: OperatorContext, operations: Record<string, a
       return; // no-op
     }
 
-    const previousLength = target.arr.length;
-    recordTruncate(context, path, { length: previousLength, count: newItems.length });
     pushToArray(target.arr, newItems);
   });
 }

--- a/packages/mill/src/operators/pop.ts
+++ b/packages/mill/src/operators/pop.ts
@@ -1,5 +1,5 @@
 import { removeIndices, resolveArrayTarget } from "../array-ops";
-import { undoPushSpec } from "../undo";
+import { recordInverse } from "../undo";
 import { cloneValue } from "../util";
 import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
@@ -14,11 +14,14 @@ export function $pop(context: OperatorContext, operations: Record<string, 1 | -1
     }
     if (direction === -1) {
       const removed = cloneValue(arr[0]);
-      undoPushSpec(context.undo, context.raw, path, { $each: [removed], $position: 0 });
+      recordInverse(context.undo, context.raw, path, "$push", {
+        $each: [removed],
+        $position: 0,
+      });
       removeIndices(arr, (index) => index === 0);
     } else {
       const removed = cloneValue(arr[arr.length - 1]);
-      undoPushSpec(context.undo, context.raw, path, removed);
+      recordInverse(context.undo, context.raw, path, "$push", removed);
       removeIndices(arr, (index) => index === arr.length - 1);
     }
   });

--- a/packages/mill/src/operators/pop.ts
+++ b/packages/mill/src/operators/pop.ts
@@ -14,12 +14,12 @@ export function $pop(context: OperatorContext, operations: Record<string, 1 | -1
     }
     if (direction === -1) {
       const removed = cloneValue(arr[0]);
+      undoPushSpec(context.undo, context.raw, path, { $each: [removed], $position: 0 });
       removeIndices(arr, (index) => index === 0);
-      undoPushSpec(context.undo, path, { $each: [removed], $position: 0 });
     } else {
       const removed = cloneValue(arr[arr.length - 1]);
+      undoPushSpec(context.undo, context.raw, path, removed);
       removeIndices(arr, (index) => index === arr.length - 1);
-      undoPushSpec(context.undo, path, removed);
     }
   });
 }

--- a/packages/mill/src/operators/pop.ts
+++ b/packages/mill/src/operators/pop.ts
@@ -1,6 +1,4 @@
 import { removeIndices, resolveArrayTarget } from "../array-ops";
-import { recordInverse } from "../undo";
-import { cloneValue } from "../util";
 import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 export function $pop(context: OperatorContext, operations: Record<string, 1 | -1>): void {
@@ -12,17 +10,7 @@ export function $pop(context: OperatorContext, operations: Record<string, 1 | -1
     if (arr === undefined || arr.length === 0) {
       return; // absent or empty — no-op
     }
-    if (direction === -1) {
-      const removed = cloneValue(arr[0]);
-      recordInverse(context.undo, context.raw, path, "$push", {
-        $each: [removed],
-        $position: 0,
-      });
-      removeIndices(arr, (index) => index === 0);
-    } else {
-      const removed = cloneValue(arr[arr.length - 1]);
-      recordInverse(context.undo, context.raw, path, "$push", removed);
-      removeIndices(arr, (index) => index === arr.length - 1);
-    }
+    const target = direction === -1 ? 0 : arr.length - 1;
+    removeIndices(arr, (index) => index === target);
   });
 }

--- a/packages/mill/src/operators/push.ts
+++ b/packages/mill/src/operators/push.ts
@@ -2,7 +2,7 @@ import { setProperty } from "@supergrain/kernel/internal";
 
 import { applyPushModifiers, parsePushSpec, pushToArray, resolveArrayTarget } from "../array-ops";
 import { setValueAtPath } from "../path";
-import { capturePathUndo, undoSet, undoTruncate } from "../undo";
+import { capturePathUndo, undoSetArray, undoTruncate } from "../undo";
 import { cloneValue, isEqual } from "../util";
 import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
@@ -31,8 +31,11 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
         return; // no-op
       }
       const previousLength = arr.length;
+      undoTruncate(context.undo, context.raw, path, {
+        length: previousLength,
+        count: items.length,
+      });
       pushToArray(arr, items);
-      undoTruncate(context.undo, path, { length: previousLength, count: items.length });
       return;
     }
 
@@ -44,7 +47,7 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
     if (isEqual(next, previousArray)) {
       return; // no-op
     }
+    undoSetArray(context.undo, context.raw, path, previousArray);
     setProperty(target.parent, target.key, next);
-    undoSet(context.undo, path, previousArray);
   });
 }

--- a/packages/mill/src/operators/push.ts
+++ b/packages/mill/src/operators/push.ts
@@ -2,9 +2,9 @@ import { setProperty } from "@supergrain/kernel/internal";
 
 import { applyPushModifiers, parsePushSpec, pushToArray, resolveArrayTarget } from "../array-ops";
 import { setValueAtPath } from "../path";
-import { capturePathUndo, undoSetArray, undoTruncate } from "../undo";
+import { capturePathUndo, recordInverse } from "../undo";
 import { cloneValue, isEqual } from "../util";
-import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
+import { eachPath, type OperatorContext, pathWriteOptions, recordTruncate } from "./shared";
 
 export function $push(context: OperatorContext, operations: Record<string, any>): void {
   eachPath(context, operations, (path, spec) => {
@@ -31,10 +31,7 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
         return; // no-op
       }
       const previousLength = arr.length;
-      undoTruncate(context.undo, context.raw, path, {
-        length: previousLength,
-        count: items.length,
-      });
+      recordTruncate(context, path, { length: previousLength, count: items.length });
       pushToArray(arr, items);
       return;
     }
@@ -47,7 +44,7 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
     if (isEqual(next, previousArray)) {
       return; // no-op
     }
-    undoSetArray(context.undo, context.raw, path, previousArray);
+    recordInverse(context.undo, context.raw, path, "$set", previousArray);
     setProperty(target.parent, target.key, next);
   });
 }

--- a/packages/mill/src/operators/push.ts
+++ b/packages/mill/src/operators/push.ts
@@ -2,9 +2,8 @@ import { setProperty } from "@supergrain/kernel/internal";
 
 import { applyPushModifiers, parsePushSpec, pushToArray, resolveArrayTarget } from "../array-ops";
 import { setValueAtPath } from "../path";
-import { capturePathUndo, recordInverse } from "../undo";
-import { cloneValue, isEqual } from "../util";
-import { eachPath, type OperatorContext, pathWriteOptions, recordTruncate } from "./shared";
+import { isEqual } from "../util";
+import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
 export function $push(context: OperatorContext, operations: Record<string, any>): void {
   eachPath(context, operations, (path, spec) => {
@@ -12,10 +11,8 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
     const { items, position, slice, sort } = parsePushSpec(spec);
 
     if (target.arr === undefined) {
-      // Absent field — Mongo creates the array (applying any modifiers). The
-      // inverse is to remove the field it created.
+      // Absent field — Mongo creates the array (applying any modifiers).
       const created = applyPushModifiers([], items, { position, slice, sort });
-      capturePathUndo(context.undo, context.raw, path);
       setValueAtPath(context.raw, path, created, pathWriteOptions(context));
       return;
     }
@@ -30,21 +27,16 @@ export function $push(context: OperatorContext, operations: Record<string, any>)
       if (items.length === 0) {
         return; // no-op
       }
-      const previousLength = arr.length;
-      recordTruncate(context, path, { length: previousLength, count: items.length });
       pushToArray(arr, items);
       return;
     }
 
     // Hard case ($position into the middle, $sort, $slice): compute the result
-    // per Mongo semantics, replace the array wholesale, and restore the prior
-    // array on undo.
-    const previousArray = cloneValue(arr) as Array<any>;
+    // per Mongo semantics and replace the array wholesale.
     const next = applyPushModifiers(arr, items, { position, slice, sort });
-    if (isEqual(next, previousArray)) {
+    if (isEqual(next, arr)) {
       return; // no-op
     }
-    recordInverse(context.undo, context.raw, path, "$set", previousArray);
     setProperty(target.parent, target.key, next);
   });
 }

--- a/packages/mill/src/operators/rename.ts
+++ b/packages/mill/src/operators/rename.ts
@@ -1,6 +1,5 @@
 import { deleteValueAtPath, resolveParentPath, setValueAtPath, splitPath } from "../path";
 import { resolvePaths } from "../query";
-import { capturePathUndo } from "../undo";
 import { isContainer } from "../util";
 import { type OperatorContext, pathWriteOptions } from "./shared";
 
@@ -58,7 +57,7 @@ function planRename(context: OperatorContext, rawFrom: string, rawTo: string): R
     return null; // missing leaf under a real object — Mongo treats this as a no-op
   }
   // An existing destination is overwritten (Mongo removes it and renames the
-  // source onto it); the undo restores it via capturePathUndo below.
+  // source onto it).
   return { from, to, value: source.parent[source.key] };
 }
 
@@ -74,10 +73,6 @@ export function $rename(context: OperatorContext, operations: Record<string, str
   }
 
   for (const { from, to, value } of moves) {
-    // Undo: remove the destination (it didn't exist before) and restore the
-    // source. Capture the destination inverse before creating it.
-    capturePathUndo(context.undo, context.raw, to);
-    capturePathUndo(context.undo, context.raw, from);
     deleteValueAtPath(context.raw, from);
     setValueAtPath(context.raw, to, value, pathWriteOptions(context));
   }

--- a/packages/mill/src/operators/rename.ts
+++ b/packages/mill/src/operators/rename.ts
@@ -1,7 +1,7 @@
 import { deleteValueAtPath, resolveParentPath, setValueAtPath, splitPath } from "../path";
 import { resolvePaths } from "../query";
-import { capturePathUndo, undoSet } from "../undo";
-import { cloneValue, isContainer } from "../util";
+import { capturePathUndo } from "../undo";
+import { isContainer } from "../util";
 import { type OperatorContext, pathWriteOptions } from "./shared";
 
 interface RenameMove {
@@ -77,7 +77,7 @@ export function $rename(context: OperatorContext, operations: Record<string, str
     // Undo: remove the destination (it didn't exist before) and restore the
     // source. Capture the destination inverse before creating it.
     capturePathUndo(context.undo, context.raw, to);
-    undoSet(context.undo, from, cloneValue(value));
+    capturePathUndo(context.undo, context.raw, from);
     deleteValueAtPath(context.raw, from);
     setValueAtPath(context.raw, to, value, pathWriteOptions(context));
   }

--- a/packages/mill/src/operators/set.ts
+++ b/packages/mill/src/operators/set.ts
@@ -1,5 +1,4 @@
 import { getValueAtPath, hasValueAtPath, setValueAtPath } from "../path";
-import { capturePathUndo } from "../undo";
 import { isEqual } from "../util";
 import { eachPath, type OperatorContext, pathWriteOptions } from "./shared";
 
@@ -8,7 +7,6 @@ export function $set(context: OperatorContext, operations: Record<string, unknow
     if (hasValueAtPath(context.raw, path) && isEqual(getValueAtPath(context.raw, path), value)) {
       return; // no-op
     }
-    capturePathUndo(context.undo, context.raw, path);
     setValueAtPath(context.raw, path, value, pathWriteOptions(context));
   });
 }

--- a/packages/mill/src/operators/shared.ts
+++ b/packages/mill/src/operators/shared.ts
@@ -1,7 +1,7 @@
 import { isContiguousAscending, removeIndices, resolveArrayTarget } from "../array-ops";
 import { getValueAtPath, hasValueAtPath, setValueAtPath } from "../path";
 import { type ArrayFilter, type Query, resolvePaths } from "../query";
-import { capturePathUndo, type MutableUndo, undoPushSpec, undoSetArray } from "../undo";
+import { capturePathUndo, recordInverse, type Undo } from "../undo";
 import { cloneValue, describeValue, isEqual } from "../util";
 
 // Shared execution context + helpers used by every operator. Each operator
@@ -10,7 +10,7 @@ import { cloneValue, describeValue, isEqual } from "../util";
 
 export interface OperatorContext {
   raw: object;
-  undo: MutableUndo;
+  undo: Undo;
   query: Query;
   arrayFilters: ReadonlyArray<ArrayFilter>;
   // When set, `null` intermediates/targets are treated as absent — created for
@@ -111,14 +111,32 @@ export function removeByPredicate(
   }
 
   if (isContiguousAscending(removedIndices)) {
-    undoPushSpec(context.undo, context.raw, path, {
+    recordInverse(context.undo, context.raw, path, "$push", {
       $each: removedValues,
       $position: removedIndices[0],
     });
   } else {
-    undoSetArray(context.undo, context.raw, path, cloneValue(arr) as Array<any>);
+    recordInverse(context.undo, context.raw, path, "$set", cloneValue(arr));
   }
 
   const removedSet = new Set(removedIndices);
   removeIndices(arr, (index) => removedSet.has(index));
+}
+
+// Undo of an append ($push / $addToSet): truncate the array back to its prior
+// length — `$pop` for a single appended element, `$push` with an empty `$each`
+// and a `$slice` for several. Both standard Mongo.
+export function recordTruncate(
+  context: OperatorContext,
+  path: string,
+  append: { length: number; count: number },
+): void {
+  if (append.count === 1) {
+    recordInverse(context.undo, context.raw, path, "$pop", 1);
+  } else {
+    recordInverse(context.undo, context.raw, path, "$push", {
+      $each: [],
+      $slice: append.length,
+    });
+  }
 }

--- a/packages/mill/src/operators/shared.ts
+++ b/packages/mill/src/operators/shared.ts
@@ -1,16 +1,15 @@
-import { isContiguousAscending, removeIndices, resolveArrayTarget } from "../array-ops";
+import { removeIndices, resolveArrayTarget } from "../array-ops";
 import { getValueAtPath, hasValueAtPath, setValueAtPath } from "../path";
 import { type ArrayFilter, type Query, resolvePaths } from "../query";
-import { capturePathUndo, recordInverse, type Undo } from "../undo";
-import { cloneValue, describeValue, isEqual } from "../util";
+import { describeValue, isEqual } from "../util";
 
 // Shared execution context + helpers used by every operator. Each operator
-// receives the unwrapped document, the undo accumulator, and the query +
-// arrayFilters needed to resolve positional paths.
+// receives the unwrapped document and the query + arrayFilters needed to
+// resolve positional paths. Undo is derived outside the operators (see
+// undo.ts), so they only mutate.
 
 export interface OperatorContext {
   raw: object;
-  undo: Undo;
   query: Query;
   arrayFilters: ReadonlyArray<ArrayFilter>;
   // When set, `null` intermediates/targets are treated as absent — created for
@@ -78,15 +77,12 @@ export function writeNumeric(context: OperatorContext, path: string, write: Nume
   if (hasValueAtPath(context.raw, path) && isEqual(previous, next)) {
     return; // no-op
   }
-  capturePathUndo(context.undo, context.raw, path);
   setValueAtPath(context.raw, path, next, pathWriteOptions(context));
 }
 
 // ─── array removal ($pull / $pullAll) ───────────────────────────────────────
 
-// Remove every element matching `op.matches`, recording the fine-grained
-// inverse: a contiguous run re-inserts as one `$push` at its original index; a
-// scattered removal falls back to `$set`-ing the whole prior array.
+// Remove every element matching `op.matches`.
 export function removeByPredicate(
   context: OperatorContext,
   path: string,
@@ -97,46 +93,14 @@ export function removeByPredicate(
     return; // absent field — Mongo no-ops $pull / $pullAll
   }
 
-  const removedIndices: Array<number> = [];
-  const removedValues: Array<unknown> = [];
+  const removedIndices = new Set<number>();
   for (let i = 0; i < arr.length; i++) {
     if (op.matches(arr[i])) {
-      removedIndices.push(i);
-      removedValues.push(cloneValue(arr[i]));
+      removedIndices.add(i);
     }
   }
-
-  if (removedIndices.length === 0) {
+  if (removedIndices.size === 0) {
     return; // no-op
   }
-
-  if (isContiguousAscending(removedIndices)) {
-    recordInverse(context.undo, context.raw, path, "$push", {
-      $each: removedValues,
-      $position: removedIndices[0],
-    });
-  } else {
-    recordInverse(context.undo, context.raw, path, "$set", cloneValue(arr));
-  }
-
-  const removedSet = new Set(removedIndices);
-  removeIndices(arr, (index) => removedSet.has(index));
-}
-
-// Undo of an append ($push / $addToSet): truncate the array back to its prior
-// length — `$pop` for a single appended element, `$push` with an empty `$each`
-// and a `$slice` for several. Both standard Mongo.
-export function recordTruncate(
-  context: OperatorContext,
-  path: string,
-  append: { length: number; count: number },
-): void {
-  if (append.count === 1) {
-    recordInverse(context.undo, context.raw, path, "$pop", 1);
-  } else {
-    recordInverse(context.undo, context.raw, path, "$push", {
-      $each: [],
-      $slice: append.length,
-    });
-  }
+  removeIndices(arr, (index) => removedIndices.has(index));
 }

--- a/packages/mill/src/operators/shared.ts
+++ b/packages/mill/src/operators/shared.ts
@@ -1,7 +1,7 @@
 import { isContiguousAscending, removeIndices, resolveArrayTarget } from "../array-ops";
 import { getValueAtPath, hasValueAtPath, setValueAtPath } from "../path";
 import { type ArrayFilter, type Query, resolvePaths } from "../query";
-import { capturePathUndo, type MutableUndo, undoPushSpec, undoSet } from "../undo";
+import { capturePathUndo, type MutableUndo, undoPushSpec, undoSetArray } from "../undo";
 import { cloneValue, describeValue, isEqual } from "../util";
 
 // Shared execution context + helpers used by every operator. Each operator
@@ -110,13 +110,15 @@ export function removeByPredicate(
     return; // no-op
   }
 
-  const previousArray = cloneValue(arr) as Array<any>;
+  if (isContiguousAscending(removedIndices)) {
+    undoPushSpec(context.undo, context.raw, path, {
+      $each: removedValues,
+      $position: removedIndices[0],
+    });
+  } else {
+    undoSetArray(context.undo, context.raw, path, cloneValue(arr) as Array<any>);
+  }
+
   const removedSet = new Set(removedIndices);
   removeIndices(arr, (index) => removedSet.has(index));
-
-  if (isContiguousAscending(removedIndices)) {
-    undoPushSpec(context.undo, path, { $each: removedValues, $position: removedIndices[0] });
-  } else {
-    undoSet(context.undo, path, previousArray);
-  }
 }

--- a/packages/mill/src/operators/unset.ts
+++ b/packages/mill/src/operators/unset.ts
@@ -1,5 +1,4 @@
 import { hasValueAtPath, unsetValueAtPath } from "../path";
-import { capturePathUndo } from "../undo";
 import { eachPath, type OperatorContext } from "./shared";
 
 export function $unset(context: OperatorContext, operations: Record<string, unknown>): void {
@@ -7,7 +6,6 @@ export function $unset(context: OperatorContext, operations: Record<string, unkn
     if (!hasValueAtPath(context.raw, path)) {
       return; // no-op
     }
-    capturePathUndo(context.undo, context.raw, path);
     unsetValueAtPath(context.raw, path);
   });
 }

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -182,6 +182,13 @@ export function ensureParentPath(
 
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i]!;
+    // An array only has index fields: Mongo rejects stepping into one via a
+    // non-index segment rather than creating a string key on the array.
+    if (Array.isArray(current) && !isArrayIndex(part)) {
+      throw new TypeError(
+        `Cannot create field '${part}' in element {${parts[i - 1]}: ${JSON.stringify(current)}}.`,
+      );
+    }
     const existing = (current as any)[part];
     // A `null` intermediate is normally a hard error (Mongo can't create a
     // field inside null); with `allowNullIntermediates` it's treated as absent
@@ -217,7 +224,14 @@ export function setValueAtPath(
   options: PathWriteOptions,
 ): void {
   const { parent, key } = ensureParentPath(target, path, options);
-  if (Array.isArray(parent) && isArrayIndex(key)) {
+  if (Array.isArray(parent)) {
+    // An array only has index fields — Mongo rejects a non-index leaf.
+    if (!isArrayIndex(key)) {
+      const parentSegment = splitPath(path).at(-2);
+      throw new TypeError(
+        `Cannot create field '${key}' in element {${parentSegment}: ${JSON.stringify(parent)}}.`,
+      );
+    }
     // Writing past the end grows the array; Mongo pads the gap with null rather
     // than leaving holes. e.g. [1] + "scores.3" -> [1, null, null, 4].
     for (let i = parent.length; i < Number(key); i++) {

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -107,6 +107,32 @@ export function splitPath(path: string): Array<PathSegment> {
   return parts;
 }
 
+/**
+ * Whether `ancestor` covers `path` — they're equal, or `ancestor` names a
+ * segment-wise prefix of `path`, so writing `ancestor` also writes everything
+ * `path` names. e.g. "a" covers "a" and "a.b"; "a.b" covers neither "a" nor
+ * "a.c". Directional: `pathCovers("a.b", "a")` is false.
+ */
+export function pathCovers(ancestor: string, path: string): boolean {
+  // A segment-wise prefix is exactly a string prefix that lands on a separator:
+  // `path` covered by `ancestor` means `path` is `ancestor` + "." + the rest, and
+  // splitting that always reproduces `ancestor`'s segments first. The boundary
+  // check is what keeps "a" from covering "ab". Done on the raw strings so this
+  // stays allocation-free — it runs against every recorded undo entry.
+  return (
+    path.startsWith(ancestor) && (path.length === ancestor.length || path[ancestor.length] === ".")
+  );
+}
+
+/**
+ * Two update paths conflict when either covers the other — MongoDB rejects such
+ * an update rather than applying both. e.g. "a" conflicts with "a" and "a.b";
+ * "a.b" and "a.c" don't.
+ */
+export function pathsConflict(a: string, b: string): boolean {
+  return pathCovers(a, b) || pathCovers(b, a);
+}
+
 export function resolveParentPath(
   target: object,
   path: string,

--- a/packages/mill/src/path.ts
+++ b/packages/mill/src/path.ts
@@ -169,6 +169,12 @@ export interface PathWriteOptions {
   allowNullIntermediates: boolean;
 }
 
+// The `{field: value}` element label used in Mongo-style errors. When the
+// blocking value sits at the document root there is no field name to show.
+function describeElement(segment: string | undefined, value: unknown): string {
+  return segment === undefined ? JSON.stringify(value) : `{${segment}: ${JSON.stringify(value)}}`;
+}
+
 export function ensureParentPath(
   target: object,
   path: string,
@@ -186,7 +192,7 @@ export function ensureParentPath(
     // non-index segment rather than creating a string key on the array.
     if (Array.isArray(current) && !isArrayIndex(part)) {
       throw new TypeError(
-        `Cannot create field '${part}' in element {${parts[i - 1]}: ${JSON.stringify(current)}}.`,
+        `Cannot create field '${part}' in element ${describeElement(parts[i - 1], current)}.`,
       );
     }
     const existing = (current as any)[part];
@@ -227,9 +233,8 @@ export function setValueAtPath(
   if (Array.isArray(parent)) {
     // An array only has index fields — Mongo rejects a non-index leaf.
     if (!isArrayIndex(key)) {
-      const parentSegment = splitPath(path).at(-2);
       throw new TypeError(
-        `Cannot create field '${key}' in element {${parentSegment}: ${JSON.stringify(parent)}}.`,
+        `Cannot create field '${key}' in element ${describeElement(splitPath(path).at(-2), parent)}.`,
       );
     }
     // Writing past the end grows the array; Mongo pads the gap with null rather

--- a/packages/mill/src/undo.ts
+++ b/packages/mill/src/undo.ts
@@ -1,215 +1,186 @@
-import { isArrayIndex, splitPath } from "./path";
-import { cloneValue, isContainer } from "./util";
+import { cloneValue, isEqual } from "./util";
 
-// ─── undo accumulation ──────────────────────────────────────────────────────
+// ─── undo via copy-once, compare-once ───────────────────────────────────────
 //
-// Undo notes are collected in two structures:
-//
-// `shadow` — a tree mirroring the document that records original state: each
-// leaf says "this spot held this value" (emitted as `$set`) or "this spot
-// didn't exist" (emitted as `$unset`). Recording walks down the tree, and the
-// walk stopping at an existing leaf is what keeps the undo document legal
-// (Mongo rejects an update where one path contains another): nothing can be
-// recorded inside a region that is already being restored wholesale, because
-// there is no place in the tree to put it.
-//
-// `inverses` — granular array instructions (an append undoes with `$pop`, a
-// `$pop` with `$push`, ...) recorded by the operators. They are stored and
-// emitted verbatim; only the operator that recorded one knows what it means.
-// An instruction whose path passes through an ancestor array is not recorded —
-// the outer array is snapshotted into `shadow` instead (restoring it undoes
-// the inner edit too). That keeps instructions out of any region a whole-array
-// snapshot could cover, so the two structures never overlap; instructions
-// never overlap each other because update paths are disjoint (checked before
-// anything applies).
+// `update()` copies the top-level fields its paths touch before applying
+// anything, then compares the result against the copies and emits the edits
+// that turn it back. Because the undo document is derived from two settled
+// states in a single walk — which at every spot either descends or emits,
+// never both — its paths can never conflict, no matter what the operators did
+// in between. The operators contain no undo code at all.
 
-type ShadowNode =
-  | { kind: "branch"; children: ShadowChildren }
-  | { kind: "value"; value: unknown }
-  | { kind: "absent" };
-
-type ShadowChildren = Map<string, ShadowNode>;
-
-export interface Undo {
-  shadow: ShadowChildren;
-  inverses: Array<{ operator: string; path: string; operand: unknown }>;
+interface OriginalField {
+  present: boolean;
+  value?: unknown;
 }
 
-export function createUndo(): Undo {
-  return { shadow: new Map(), inverses: [] };
-}
+export type Originals = Map<string, OriginalField>;
 
-// Walk to the map that holds the leaf for `parts`, creating branches along the
-// way. Null when the walk runs into an existing leaf: the region is already
-// being restored wholesale, so there is nothing further to record.
-function childrenFor(shadow: ShadowChildren, parts: ReadonlyArray<string>): ShadowChildren | null {
-  let children = shadow;
-  for (let i = 0; i < parts.length - 1; i++) {
-    const existing = children.get(parts[i]!);
-    if (existing === undefined) {
-      const branch = { kind: "branch", children: new Map<string, ShadowNode>() } as const;
-      children.set(parts[i]!, branch);
-      ({ children } = branch);
-    } else if (existing.kind === "branch") {
-      ({ children } = existing);
-    } else {
-      return null;
+/**
+ * Clone the original state of every top-level field the update can touch —
+ * the first segment of each operator path (and of each `$rename` destination).
+ * Must run before the update mutates the document.
+ */
+export function captureOriginals(raw: object, operations: Record<string, object>): Originals {
+  const originals: Originals = new Map();
+  for (const [operator, payload] of Object.entries(operations)) {
+    for (const [path, target] of Object.entries(payload as Record<string, unknown>)) {
+      captureRoot(originals, raw, path);
+      if (operator === "$rename") {
+        captureRoot(originals, raw, target as string);
+      }
     }
   }
-  return children;
+  return originals;
 }
 
-function recordValue(shadow: ShadowChildren, parts: ReadonlyArray<string>, value: unknown): void {
-  const children = childrenFor(shadow, parts);
-  if (children === null) {
+function captureRoot(originals: Originals, raw: object, path: string): void {
+  const root = path.split(".")[0]!;
+  if (!originals.has(root)) {
+    originals.set(
+      root,
+      Object.hasOwn(raw, root)
+        ? { present: true, value: cloneValue((raw as Record<string, unknown>)[root]) }
+        : { present: false },
+    );
+  }
+}
+
+type UndoDocument = Record<string, Record<string, unknown>>;
+
+/** Compare the mutated document against the originals and emit the undo. */
+export function buildUndo(raw: object, originals: Originals): UndoDocument {
+  const undo: UndoDocument = {};
+  for (const [root, original] of originals) {
+    const present = Object.hasOwn(raw, root);
+    if (!original.present) {
+      if (present) {
+        unset(undo, root);
+      }
+    } else if (present) {
+      restore(undo, root, original.value, (raw as Record<string, unknown>)[root]);
+    } else {
+      set(undo, root, original.value);
+    }
+  }
+  return undo;
+}
+
+function set(undo: UndoDocument, path: string, value: unknown): void {
+  (undo["$set"] ??= {})[path] = value;
+}
+
+function unset(undo: UndoDocument, path: string): void {
+  (undo["$unset"] ??= {})[path] = "";
+}
+
+// Emit the edits that turn `after` (live) back into `before` (a pristine
+// clone). Descend while both sides stay structural so the restore lands on the
+// smallest spots that changed; anything else restores wholesale.
+function restore(undo: UndoDocument, path: string, before: unknown, after: unknown): void {
+  if (Array.isArray(before) && Array.isArray(after)) {
+    restoreArray(undo, path, before, after);
+  } else if (
+    isPlainObject(before) &&
+    isPlainObject(after) &&
+    // A prototype-flavor change (null-prototype replaced by plain, or vice
+    // versa) can only be restored wholesale — patching inside the replacement
+    // would keep its flavor.
+    Object.getPrototypeOf(before) === Object.getPrototypeOf(after) &&
+    keysAddressable(before) &&
+    keysAddressable(after)
+  ) {
+    restoreObject(undo, path, before, after);
+  } else if (!isEqual(before, after)) {
+    set(undo, path, before);
+  }
+}
+
+// Dates, class instances, and null/scalars restore wholesale — only plain
+// (or null-prototype) objects are walked into.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+// A key that is empty or contains a dot can't be named by a Mongo path, so an
+// object holding one restores wholesale.
+function keysAddressable(value: Record<string, unknown>): boolean {
+  return Object.keys(value).every((key) => /^[^.]+$/u.test(key));
+}
+
+function restoreObject(
+  undo: UndoDocument,
+  path: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    const childPath = `${path}.${key}`;
+    if (!Object.hasOwn(before, key)) {
+      unset(undo, childPath);
+    } else if (Object.hasOwn(after, key)) {
+      restore(undo, childPath, before[key], after[key]);
+    } else {
+      set(undo, childPath, before[key]);
+    }
+  }
+}
+
+function restoreArray(
+  undo: UndoDocument,
+  path: string,
+  before: Array<unknown>,
+  after: Array<unknown>,
+): void {
+  if (before.length === after.length) {
+    for (let i = 0; i < before.length; i++) {
+      restore(undo, `${path}.${i}`, before[i], after[i]);
+    }
     return;
   }
-  const key = parts[parts.length - 1]!;
-  const existing = children.get(key);
-  if (existing !== undefined) {
-    if (existing.kind !== "branch") {
-      return; // this exact spot is already restored — the earlier note wins
-    }
-    // A whole-array snapshot arriving after notes about spots inside it (an
-    // out-of-bounds write following an in-bounds one). The snapshot copied the
-    // array *after* those spots were changed, but each note holds the original
-    // value, so writing the notes back into the snapshot reproduces the
-    // pristine array — and replacing the branch consumes them.
-    foldInto(value as object, existing.children);
-  }
-  children.set(key, { kind: "value", value });
-}
 
-function recordAbsent(shadow: ShadowChildren, parts: ReadonlyArray<string>): void {
-  const children = childrenFor(shadow, parts);
-  if (children !== null) {
-    children.set(parts[parts.length - 1]!, { kind: "absent" });
-  }
-}
-
-function foldInto(snapshot: object, children: ShadowChildren): void {
-  for (const [key, node] of children) {
-    if (node.kind === "branch") {
-      foldInto((snapshot as Record<string, object>)[key]!, node.children);
-    } else if (node.kind === "value") {
-      (snapshot as Record<string, unknown>)[key] = node.value;
+  // Elements were appended: truncate back — `$pop` for one, `$slice` for more.
+  if (after.length > before.length && prefixEqual(after, before, before.length)) {
+    if (after.length - before.length === 1) {
+      (undo["$pop"] ??= {})[path] = 1;
     } else {
-      delete (snapshot as Record<string, unknown>)[key];
+      (undo["$push"] ??= {})[path] = { $each: [], $slice: before.length };
     }
+    return;
   }
-}
 
-/**
- * Record a granular array instruction — emitted into the undo document as
- * `{ [operator]: { [path]: operand } }`, uninterpreted. Falls back to
- * snapshotting the outer array when `path` passes through one.
- */
-export function recordInverse(
-  undo: Undo,
-  raw: object,
-  path: string,
-  operator: string,
-  operand: unknown,
-): void {
-  const parts = splitPath(path);
-  let current: unknown = raw;
-  for (let i = 1; i < parts.length; i++) {
-    current = (current as Record<string, unknown>)[parts[i - 1]!];
-    if (Array.isArray(current)) {
-      recordValue(undo.shadow, parts.slice(0, i), cloneValue(current));
-      return;
+  // A contiguous run was removed: push it back where it was. A single element
+  // taken from the end re-appends as a plain `$push`.
+  if (before.length > after.length) {
+    const count = before.length - after.length;
+    let start = 0;
+    while (start < after.length && isEqual(before[start], after[start])) {
+      start++;
     }
-  }
-  undo.inverses.push({ operator, path, operand });
-}
-
-/**
- * Record the note needed to restore the value at `path` before a write.
- * Restores previous state *exactly*, including missing-vs-present: if the
- * write creates an absent branch, the undo `$unset`s the shallowest segment
- * that didn't exist; if it overwrites, the undo `$set`s the prior value back.
- * Must be called before the write is applied.
- */
-export function capturePathUndo(undo: Undo, raw: object, path: string): void {
-  const parts = splitPath(path);
-  let current: any = raw;
-
-  for (let i = 0; i < parts.length - 1; i++) {
-    const segment = parts[i]!;
-    // Growing a (nested) array through an out-of-bounds *intermediate* index
-    // pads it with null; like the leaf case below, the only exact inverse is to
-    // restore the whole prior array rather than $unset a single grown index.
-    if (
-      i > 0 &&
-      Array.isArray(current) &&
-      isArrayIndex(segment) &&
-      Number(segment) >= current.length
-    ) {
-      recordValue(undo.shadow, parts.slice(0, i), cloneValue(current));
-      return;
-    }
-    if (
-      !isContainer(current) ||
-      !Object.hasOwn(current, segment) ||
-      !isContainer((current as any)[segment])
-    ) {
-      const prefix = parts.slice(0, i + 1);
-      if (isContainer(current) && Object.hasOwn(current, segment)) {
-        // A non-container value (e.g. a number) is about to be overwritten by a
-        // freshly-created branch — snapshot it so undo restores it exactly.
-        recordValue(undo.shadow, prefix, cloneValue((current as any)[segment]));
+    if (prefixEqual(after.slice(start), before.slice(start + count), after.length - start)) {
+      const run = before.slice(start, start + count);
+      if (count === 1 && start === after.length) {
+        const [removed] = run;
+        (undo["$push"] ??= {})[path] = removed;
       } else {
-        recordAbsent(undo.shadow, prefix);
+        (undo["$push"] ??= {})[path] = { $each: run, $position: start };
       }
       return;
     }
-    current = (current as any)[segment];
   }
 
-  const leafKey = parts[parts.length - 1]!;
-
-  // Writing past the end of an array grows it (Mongo pads with null). The only
-  // exact, replayable inverse is to restore the whole prior array.
-  if (
-    Array.isArray(current) &&
-    isArrayIndex(leafKey) &&
-    Number(leafKey) >= current.length &&
-    parts.length > 1
-  ) {
-    recordValue(undo.shadow, parts.slice(0, -1), cloneValue(current));
-    return;
-  }
-
-  if (isContainer(current) && Object.hasOwn(current, leafKey)) {
-    recordValue(undo.shadow, parts, cloneValue((current as any)[leafKey]));
-  } else {
-    recordAbsent(undo.shadow, parts);
-  }
+  set(undo, path, before);
 }
 
-/** Emit the collected notes as a flat, conflict-free Mongo update document. */
-export function buildUndoDocument(undo: Undo): Record<string, Record<string, unknown>> {
-  const doc: Record<string, Record<string, unknown>> = {};
-  emit(undo.shadow, "", doc);
-  for (const { operator, path, operand } of undo.inverses) {
-    (doc[operator] ??= {})[path] = operand;
-  }
-  return doc;
-}
-
-function emit(
-  children: ShadowChildren,
-  prefix: string,
-  doc: Record<string, Record<string, unknown>>,
-): void {
-  for (const [key, node] of children) {
-    const path = prefix === "" ? key : `${prefix}.${key}`;
-    if (node.kind === "branch") {
-      emit(node.children, path, doc);
-    } else if (node.kind === "value") {
-      (doc["$set"] ??= {})[path] = node.value;
-    } else {
-      (doc["$unset"] ??= {})[path] = "";
+function prefixEqual(a: Array<unknown>, b: Array<unknown>, length: number): boolean {
+  for (let i = 0; i < length; i++) {
+    if (!isEqual(a[i], b[i])) {
+      return false;
     }
   }
+  return true;
 }

--- a/packages/mill/src/undo.ts
+++ b/packages/mill/src/undo.ts
@@ -1,168 +1,136 @@
-import { getValueAtPath, isArrayIndex, pathCovers, splitPath } from "./path";
+import { isArrayIndex, splitPath } from "./path";
 import { cloneValue, isContainer } from "./util";
 
 // ─── undo accumulation ──────────────────────────────────────────────────────
 //
-// The undo document only ever needs four operators to invert anything: `$set`
-// and `$unset` for scalar/whole-value restores, and `$push`/`$pop` for the
-// fine-grained array inverses. Array edits whose inverse can't be expressed by
-// a single granular operator (a scattered `$pull`, a `$sort`, any op on an
-// array nested inside another array) fall back to `$set`-ing the whole prior
-// array.
+// Undo notes are collected in two structures:
 //
-// The undo document must itself be a legal Mongo update, so no entry's path may
-// prefix another's. Recording happens before each op mutates, and two rules
-// keep the accumulated entries conflict-free:
+// `shadow` — a tree mirroring the document that records original state: each
+// leaf says "this spot held this value" (emitted as `$set`) or "this spot
+// didn't exist" (emitted as `$unset`). Recording walks down the tree, and the
+// walk stopping at an existing leaf is what keeps the undo document legal
+// (Mongo rejects an update where one path contains another): nothing can be
+// recorded inside a region that is already being restored wholesale, because
+// there is no place in the tree to put it.
 //
-//   - An entry covered by an existing entry at an ancestor path is skipped —
-//     that ancestor already restores the whole region.
-//   - A whole-array restore can also arrive *after* entries beneath it (an
-//     out-of-bounds index write following an in-bounds one). Its clone of the
-//     array is stale — earlier ops already wrote into it — but each such write
-//     left an entry holding the original value, so absorbing those entries
-//     into the clone reproduces the pristine array (and dropping them removes
-//     the conflict).
-//
-// Absorption only ever meets `$set`/`$unset` entries: a granular `$push`/`$pop`
-// inverse whose own path runs through an ancestor array is recorded as that
-// array's whole-array restore instead, so no granular entry can sit beneath an
-// array for a later restore to collide with.
+// `inverses` — granular array instructions (an append undoes with `$pop`, a
+// `$pop` with `$push`, ...) recorded by the operators. They are stored and
+// emitted verbatim; only the operator that recorded one knows what it means.
+// An instruction whose path passes through an ancestor array is not recorded —
+// the outer array is snapshotted into `shadow` instead (restoring it undoes
+// the inner edit too). That keeps instructions out of any region a whole-array
+// snapshot could cover, so the two structures never overlap; instructions
+// never overlap each other because update paths are disjoint (checked before
+// anything applies).
 
-export interface MutableUndo {
-  $set?: Record<string, unknown>;
-  $unset?: Record<string, "">;
-  $push?: Record<string, unknown>;
-  $pop?: Record<string, 1 | -1>;
+type ShadowNode =
+  | { kind: "branch"; children: ShadowChildren }
+  | { kind: "value"; value: unknown }
+  | { kind: "absent" };
+
+type ShadowChildren = Map<string, ShadowNode>;
+
+export interface Undo {
+  shadow: ShadowChildren;
+  inverses: Array<{ operator: string; path: string; operand: unknown }>;
 }
 
-function coveredByExistingEntry(undo: MutableUndo, path: string): boolean {
-  for (const existingOps of Object.values(undo)) {
-    for (const existingOpPath of Object.keys(existingOps as Record<string, unknown>)) {
-      if (pathCovers(existingOpPath, path)) {
-        return true;
-      }
+export function createUndo(): Undo {
+  return { shadow: new Map(), inverses: [] };
+}
+
+// Walk to the map that holds the leaf for `parts`, creating branches along the
+// way. Null when the walk runs into an existing leaf: the region is already
+// being restored wholesale, so there is nothing further to record.
+function childrenFor(shadow: ShadowChildren, parts: ReadonlyArray<string>): ShadowChildren | null {
+  let children = shadow;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const existing = children.get(parts[i]!);
+    if (existing === undefined) {
+      const branch = { kind: "branch", children: new Map<string, ShadowNode>() } as const;
+      children.set(parts[i]!, branch);
+      ({ children } = branch);
+    } else if (existing.kind === "branch") {
+      ({ children } = existing);
+    } else {
+      return null;
     }
   }
-  return false;
+  return children;
 }
 
-export function undoSet(undo: MutableUndo, path: string, value: unknown): void {
-  if (coveredByExistingEntry(undo, path)) return;
-  (undo.$set ??= {})[path] = value;
+function recordValue(shadow: ShadowChildren, parts: ReadonlyArray<string>, value: unknown): void {
+  const children = childrenFor(shadow, parts);
+  if (children === null) {
+    return;
+  }
+  const key = parts[parts.length - 1]!;
+  const existing = children.get(key);
+  if (existing !== undefined) {
+    if (existing.kind !== "branch") {
+      return; // this exact spot is already restored — the earlier note wins
+    }
+    // A whole-array snapshot arriving after notes about spots inside it (an
+    // out-of-bounds write following an in-bounds one). The snapshot copied the
+    // array *after* those spots were changed, but each note holds the original
+    // value, so writing the notes back into the snapshot reproduces the
+    // pristine array — and replacing the branch consumes them.
+    foldInto(value as object, existing.children);
+  }
+  children.set(key, { kind: "value", value });
 }
 
-export function undoUnset(undo: MutableUndo, path: string): void {
-  if (coveredByExistingEntry(undo, path)) return;
-  (undo.$unset ??= {})[path] = "";
-}
-
-/**
- * Record a granular `$push` inverse. Falls back to restoring the outer array
- * when `path` runs through one.
- */
-export function undoPushSpec(undo: MutableUndo, raw: object, path: string, spec: unknown): void {
-  if (escalateThroughAncestorArray(undo, raw, path)) return;
-  (undo.$push ??= {})[path] = spec;
-}
-
-/**
- * Record the inverse of replacing the whole array at `path` (edits no granular
- * operator can invert). Falls back to restoring the outer array when `path`
- * runs through one.
- */
-export function undoSetArray(
-  undo: MutableUndo,
-  raw: object,
-  path: string,
-  previousArray: Array<unknown>,
-): void {
-  if (escalateThroughAncestorArray(undo, raw, path)) return;
-  undoSet(undo, path, previousArray);
-}
-
-/**
- * Record the inverse of an append: truncate back to the prior length — `$pop`
- * for one element, `$push` with an empty `$each` and a `$slice` for several.
- * Falls back to restoring the outer array when `path` runs through one.
- */
-export function undoTruncate(
-  undo: MutableUndo,
-  raw: object,
-  path: string,
-  append: { length: number; count: number },
-): void {
-  if (escalateThroughAncestorArray(undo, raw, path)) return;
-  if (append.count === 1) {
-    (undo.$pop ??= {})[path] = 1;
-  } else {
-    (undo.$push ??= {})[path] = { $each: [], $slice: append.length };
+function recordAbsent(shadow: ShadowChildren, parts: ReadonlyArray<string>): void {
+  const children = childrenFor(shadow, parts);
+  if (children !== null) {
+    children.set(parts[parts.length - 1]!, { kind: "absent" });
   }
 }
 
-// A granular inverse recorded beneath an array would conflict with — and could
-// not be absorbed into — a later whole-restore of that array, so record the
-// array's restore instead. False when `path` reaches its target through
-// objects only. Callers record against a resolved, existing array target, so
-// every ancestor is a container.
-function escalateThroughAncestorArray(undo: MutableUndo, raw: object, path: string): boolean {
+function foldInto(snapshot: object, children: ShadowChildren): void {
+  for (const [key, node] of children) {
+    if (node.kind === "branch") {
+      foldInto((snapshot as Record<string, object>)[key]!, node.children);
+    } else if (node.kind === "value") {
+      (snapshot as Record<string, unknown>)[key] = node.value;
+    } else {
+      delete (snapshot as Record<string, unknown>)[key];
+    }
+  }
+}
+
+/**
+ * Record a granular array instruction — emitted into the undo document as
+ * `{ [operator]: { [path]: operand } }`, uninterpreted. Falls back to
+ * snapshotting the outer array when `path` passes through one.
+ */
+export function recordInverse(
+  undo: Undo,
+  raw: object,
+  path: string,
+  operator: string,
+  operand: unknown,
+): void {
   const parts = splitPath(path);
   let current: unknown = raw;
   for (let i = 1; i < parts.length; i++) {
     current = (current as Record<string, unknown>)[parts[i - 1]!];
     if (Array.isArray(current)) {
-      undoArraySnapshot(undo, raw, parts.slice(0, i));
-      return true;
+      recordValue(undo.shadow, parts.slice(0, i), cloneValue(current));
+      return;
     }
   }
-  return false;
-}
-
-// Whole-array restore at `parts` (the array's own path), absorbing any entries
-// already recorded beneath it.
-function undoArraySnapshot(undo: MutableUndo, raw: object, parts: Array<string>): void {
-  const path = parts.join(".");
-  if (coveredByExistingEntry(undo, path)) return;
-  const snapshot = cloneValue(getValueAtPath(raw, path)) as object;
-  absorbCoveredEntries(undo, path, snapshot);
-  (undo.$set ??= {})[path] = snapshot;
-}
-
-// Write the original values held by entries under `arrayPath` back into
-// `snapshot` (a clone of the array's current state), then drop the entries.
-function absorbCoveredEntries(undo: MutableUndo, arrayPath: string, snapshot: object): void {
-  for (const operator of ["$set", "$unset"] as const) {
-    const entries = undo[operator] ?? {};
-    for (const entryPath of Object.keys(entries)) {
-      if (pathCovers(arrayPath, entryPath)) {
-        const relative = splitPath(entryPath.slice(arrayPath.length + 1));
-        let parent: any = snapshot;
-        for (let i = 0; i < relative.length - 1; i++) {
-          parent = parent[relative[i]!];
-        }
-        const key = relative[relative.length - 1]!;
-        if (operator === "$set") {
-          parent[key] = entries[entryPath];
-        } else {
-          delete parent[key];
-        }
-        delete entries[entryPath];
-      }
-    }
-    // MongoDB rejects an update with an empty operator object.
-    if (Object.keys(entries).length === 0) {
-      delete undo[operator];
-    }
-  }
+  undo.inverses.push({ operator, path, operand });
 }
 
 /**
- * Record the inverse needed to restore the value at `path` before a scalar
- * write. Restores previous state *exactly*, including missing-vs-present: if the
- * write creates an absent branch, the undo `$unset`s the shallowest segment that
- * didn't exist; if it overwrites, the undo `$set`s the prior value back. Must be
- * called before the write is applied.
+ * Record the note needed to restore the value at `path` before a write.
+ * Restores previous state *exactly*, including missing-vs-present: if the
+ * write creates an absent branch, the undo `$unset`s the shallowest segment
+ * that didn't exist; if it overwrites, the undo `$set`s the prior value back.
+ * Must be called before the write is applied.
  */
-export function capturePathUndo(undo: MutableUndo, raw: object, path: string): void {
+export function capturePathUndo(undo: Undo, raw: object, path: string): void {
   const parts = splitPath(path);
   let current: any = raw;
 
@@ -177,7 +145,7 @@ export function capturePathUndo(undo: MutableUndo, raw: object, path: string): v
       isArrayIndex(segment) &&
       Number(segment) >= current.length
     ) {
-      undoArraySnapshot(undo, raw, parts.slice(0, i));
+      recordValue(undo.shadow, parts.slice(0, i), cloneValue(current));
       return;
     }
     if (
@@ -185,13 +153,13 @@ export function capturePathUndo(undo: MutableUndo, raw: object, path: string): v
       !Object.hasOwn(current, segment) ||
       !isContainer((current as any)[segment])
     ) {
-      const prefix = parts.slice(0, i + 1).join(".");
+      const prefix = parts.slice(0, i + 1);
       if (isContainer(current) && Object.hasOwn(current, segment)) {
         // A non-container value (e.g. a number) is about to be overwritten by a
         // freshly-created branch — snapshot it so undo restores it exactly.
-        undoSet(undo, prefix, cloneValue((current as any)[segment]));
+        recordValue(undo.shadow, prefix, cloneValue((current as any)[segment]));
       } else {
-        undoUnset(undo, prefix);
+        recordAbsent(undo.shadow, prefix);
       }
       return;
     }
@@ -208,13 +176,40 @@ export function capturePathUndo(undo: MutableUndo, raw: object, path: string): v
     Number(leafKey) >= current.length &&
     parts.length > 1
   ) {
-    undoArraySnapshot(undo, raw, parts.slice(0, -1));
+    recordValue(undo.shadow, parts.slice(0, -1), cloneValue(current));
     return;
   }
 
   if (isContainer(current) && Object.hasOwn(current, leafKey)) {
-    undoSet(undo, path, cloneValue((current as any)[leafKey]));
+    recordValue(undo.shadow, parts, cloneValue((current as any)[leafKey]));
   } else {
-    undoUnset(undo, path);
+    recordAbsent(undo.shadow, parts);
+  }
+}
+
+/** Emit the collected notes as a flat, conflict-free Mongo update document. */
+export function buildUndoDocument(undo: Undo): Record<string, Record<string, unknown>> {
+  const doc: Record<string, Record<string, unknown>> = {};
+  emit(undo.shadow, "", doc);
+  for (const { operator, path, operand } of undo.inverses) {
+    (doc[operator] ??= {})[path] = operand;
+  }
+  return doc;
+}
+
+function emit(
+  children: ShadowChildren,
+  prefix: string,
+  doc: Record<string, Record<string, unknown>>,
+): void {
+  for (const [key, node] of children) {
+    const path = prefix === "" ? key : `${prefix}.${key}`;
+    if (node.kind === "branch") {
+      emit(node.children, path, doc);
+    } else if (node.kind === "value") {
+      (doc["$set"] ??= {})[path] = node.value;
+    } else {
+      (doc["$unset"] ??= {})[path] = "";
+    }
   }
 }

--- a/packages/mill/src/undo.ts
+++ b/packages/mill/src/undo.ts
@@ -1,4 +1,4 @@
-import { isArrayIndex, splitPath } from "./path";
+import { isArrayIndex, pathCovers, splitPath } from "./path";
 import { cloneValue, isContainer } from "./util";
 
 // ─── undo accumulation ──────────────────────────────────────────────────────
@@ -16,19 +16,38 @@ export interface MutableUndo {
   $pop?: Record<string, 1 | -1>;
 }
 
+/**
+ * Don't record undo ops for ops that will already be undone by an op at an
+ * ancestor path. Otherwise we get a conflict.
+ */
+function coveredByExistingEntry(undo: MutableUndo, path: string): boolean {
+  for (const existingOps of Object.values(undo)) {
+    for (const existingOpPath of Object.keys(existingOps as Record<string, unknown>)) {
+      if (pathCovers(existingOpPath, path)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function undoSet(undo: MutableUndo, path: string, value: unknown): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$set ??= {})[path] = value;
 }
 
 export function undoUnset(undo: MutableUndo, path: string): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$unset ??= {})[path] = "";
 }
 
 export function undoPushSpec(undo: MutableUndo, path: string, spec: unknown): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$push ??= {})[path] = spec;
 }
 
 export function undoPop(undo: MutableUndo, path: string, direction: 1 | -1): void {
+  if (coveredByExistingEntry(undo, path)) return;
   (undo.$pop ??= {})[path] = direction;
 }
 

--- a/packages/mill/src/undo.ts
+++ b/packages/mill/src/undo.ts
@@ -1,4 +1,4 @@
-import { isArrayIndex, pathCovers, splitPath } from "./path";
+import { getValueAtPath, isArrayIndex, pathCovers, splitPath } from "./path";
 import { cloneValue, isContainer } from "./util";
 
 // ─── undo accumulation ──────────────────────────────────────────────────────
@@ -6,8 +6,27 @@ import { cloneValue, isContainer } from "./util";
 // The undo document only ever needs four operators to invert anything: `$set`
 // and `$unset` for scalar/whole-value restores, and `$push`/`$pop` for the
 // fine-grained array inverses. Array edits whose inverse can't be expressed by
-// a single granular operator (a scattered `$pull`, a `$sort`) fall back to
-// `$set`-ing the whole prior array.
+// a single granular operator (a scattered `$pull`, a `$sort`, any op on an
+// array nested inside another array) fall back to `$set`-ing the whole prior
+// array.
+//
+// The undo document must itself be a legal Mongo update, so no entry's path may
+// prefix another's. Recording happens before each op mutates, and two rules
+// keep the accumulated entries conflict-free:
+//
+//   - An entry covered by an existing entry at an ancestor path is skipped —
+//     that ancestor already restores the whole region.
+//   - A whole-array restore can also arrive *after* entries beneath it (an
+//     out-of-bounds index write following an in-bounds one). Its clone of the
+//     array is stale — earlier ops already wrote into it — but each such write
+//     left an entry holding the original value, so absorbing those entries
+//     into the clone reproduces the pristine array (and dropping them removes
+//     the conflict).
+//
+// Absorption only ever meets `$set`/`$unset` entries: a granular `$push`/`$pop`
+// inverse whose own path runs through an ancestor array is recorded as that
+// array's whole-array restore instead, so no granular entry can sit beneath an
+// array for a later restore to collide with.
 
 export interface MutableUndo {
   $set?: Record<string, unknown>;
@@ -16,10 +35,6 @@ export interface MutableUndo {
   $pop?: Record<string, 1 | -1>;
 }
 
-/**
- * Don't record undo ops for ops that will already be undone by an op at an
- * ancestor path. Otherwise we get a conflict.
- */
 function coveredByExistingEntry(undo: MutableUndo, path: string): boolean {
   for (const existingOps of Object.values(undo)) {
     for (const existingOpPath of Object.keys(existingOps as Record<string, unknown>)) {
@@ -41,28 +56,102 @@ export function undoUnset(undo: MutableUndo, path: string): void {
   (undo.$unset ??= {})[path] = "";
 }
 
-export function undoPushSpec(undo: MutableUndo, path: string, spec: unknown): void {
-  if (coveredByExistingEntry(undo, path)) return;
+/**
+ * Record a granular `$push` inverse. Falls back to restoring the outer array
+ * when `path` runs through one.
+ */
+export function undoPushSpec(undo: MutableUndo, raw: object, path: string, spec: unknown): void {
+  if (escalateThroughAncestorArray(undo, raw, path)) return;
   (undo.$push ??= {})[path] = spec;
 }
 
-export function undoPop(undo: MutableUndo, path: string, direction: 1 | -1): void {
-  if (coveredByExistingEntry(undo, path)) return;
-  (undo.$pop ??= {})[path] = direction;
+/**
+ * Record the inverse of replacing the whole array at `path` (edits no granular
+ * operator can invert). Falls back to restoring the outer array when `path`
+ * runs through one.
+ */
+export function undoSetArray(
+  undo: MutableUndo,
+  raw: object,
+  path: string,
+  previousArray: Array<unknown>,
+): void {
+  if (escalateThroughAncestorArray(undo, raw, path)) return;
+  undoSet(undo, path, previousArray);
 }
 
-// Undo of an append: truncate the array back to its prior length. A single
-// appended element pops cleanly; multiple use `$push` with an empty `$each` and
-// a `$slice` truncation — both standard Mongo.
+/**
+ * Record the inverse of an append: truncate back to the prior length — `$pop`
+ * for one element, `$push` with an empty `$each` and a `$slice` for several.
+ * Falls back to restoring the outer array when `path` runs through one.
+ */
 export function undoTruncate(
   undo: MutableUndo,
+  raw: object,
   path: string,
   append: { length: number; count: number },
 ): void {
+  if (escalateThroughAncestorArray(undo, raw, path)) return;
   if (append.count === 1) {
-    undoPop(undo, path, 1);
+    (undo.$pop ??= {})[path] = 1;
   } else {
-    undoPushSpec(undo, path, { $each: [], $slice: append.length });
+    (undo.$push ??= {})[path] = { $each: [], $slice: append.length };
+  }
+}
+
+// A granular inverse recorded beneath an array would conflict with — and could
+// not be absorbed into — a later whole-restore of that array, so record the
+// array's restore instead. False when `path` reaches its target through
+// objects only. Callers record against a resolved, existing array target, so
+// every ancestor is a container.
+function escalateThroughAncestorArray(undo: MutableUndo, raw: object, path: string): boolean {
+  const parts = splitPath(path);
+  let current: unknown = raw;
+  for (let i = 1; i < parts.length; i++) {
+    current = (current as Record<string, unknown>)[parts[i - 1]!];
+    if (Array.isArray(current)) {
+      undoArraySnapshot(undo, raw, parts.slice(0, i));
+      return true;
+    }
+  }
+  return false;
+}
+
+// Whole-array restore at `parts` (the array's own path), absorbing any entries
+// already recorded beneath it.
+function undoArraySnapshot(undo: MutableUndo, raw: object, parts: Array<string>): void {
+  const path = parts.join(".");
+  if (coveredByExistingEntry(undo, path)) return;
+  const snapshot = cloneValue(getValueAtPath(raw, path)) as object;
+  absorbCoveredEntries(undo, path, snapshot);
+  (undo.$set ??= {})[path] = snapshot;
+}
+
+// Write the original values held by entries under `arrayPath` back into
+// `snapshot` (a clone of the array's current state), then drop the entries.
+function absorbCoveredEntries(undo: MutableUndo, arrayPath: string, snapshot: object): void {
+  for (const operator of ["$set", "$unset"] as const) {
+    const entries = undo[operator] ?? {};
+    for (const entryPath of Object.keys(entries)) {
+      if (pathCovers(arrayPath, entryPath)) {
+        const relative = splitPath(entryPath.slice(arrayPath.length + 1));
+        let parent: any = snapshot;
+        for (let i = 0; i < relative.length - 1; i++) {
+          parent = parent[relative[i]!];
+        }
+        const key = relative[relative.length - 1]!;
+        if (operator === "$set") {
+          parent[key] = entries[entryPath];
+        } else {
+          delete parent[key];
+        }
+        delete entries[entryPath];
+      }
+    }
+    // MongoDB rejects an update with an empty operator object.
+    if (Object.keys(entries).length === 0) {
+      delete undo[operator];
+    }
   }
 }
 
@@ -88,7 +177,7 @@ export function capturePathUndo(undo: MutableUndo, raw: object, path: string): v
       isArrayIndex(segment) &&
       Number(segment) >= current.length
     ) {
-      undoSet(undo, parts.slice(0, i).join("."), cloneValue(current));
+      undoArraySnapshot(undo, raw, parts.slice(0, i));
       return;
     }
     if (
@@ -119,7 +208,7 @@ export function capturePathUndo(undo: MutableUndo, raw: object, path: string): v
     Number(leafKey) >= current.length &&
     parts.length > 1
   ) {
-    undoSet(undo, parts.slice(0, -1).join("."), cloneValue(current));
+    undoArraySnapshot(undo, raw, parts.slice(0, -1));
     return;
   }
 

--- a/packages/mill/src/undo.ts
+++ b/packages/mill/src/undo.ts
@@ -1,69 +1,238 @@
-import { cloneValue, isEqual } from "./util";
+import { getValueAtPath, hasValueAtPath, isArrayIndex, pathCovers, splitPath } from "./path";
+import { cloneValue, isContainer, isEqual, isObject } from "./util";
 
-// ─── undo via copy-once, compare-once ───────────────────────────────────────
+// ─── undo via plan, apply, settle ───────────────────────────────────────────
 //
-// `update()` copies the top-level fields its paths touch before applying
-// anything, then compares the result against the copies and emits the edits
-// that turn it back. Because the undo document is derived from two settled
-// states in a single walk — which at every spot either descends or emits,
-// never both — its paths can never conflict, no matter what the operators did
-// in between. The operators contain no undo code at all.
+// Before anything runs, `planUndo` reads the update document and the pristine
+// document to decide, per path, the cheapest saved state that suffices to
+// restore it — a *spot*:
+//
+//   - `value`:  the original value at a path (what a write overwrites)
+//   - `absent`: the path didn't exist (a created branch undoes with $unset)
+//   - `length`: an array's original length (appends and past-the-end growth
+//               undo by truncating — no contents needed, so appending to a
+//               huge array plans O(1) work)
+//
+// After the update applies — the operators contain no undo code — `buildUndo`
+// compares each spot against the document and emits the edits that turn it
+// back. Every decision is made against the pristine document, so a spot's
+// saved state is exact by construction, and `addSpot` keeps spots pairwise
+// non-nested (a shallower spot widens to a full `value` and absorbs deeper
+// ones), so the emitted paths can never conflict.
 
-interface OriginalField {
-  present: boolean;
-  value?: unknown;
-}
+type Spot =
+  | { kind: "value"; path: string; value: unknown }
+  | { kind: "absent"; path: string }
+  | { kind: "length"; path: string; length: number };
 
-export type Originals = Map<string, OriginalField>;
+export type UndoPlan = Map<string, Spot>;
 
-/**
- * Clone the original state of every top-level field the update can touch —
- * the first segment of each operator path (and of each `$rename` destination).
- * Must run before the update mutates the document.
- */
-export function captureOriginals(raw: object, operations: Record<string, object>): Originals {
-  const originals: Originals = new Map();
+/** Plan what to save. Must run before the update mutates the document. */
+export function planUndo(raw: object, operations: Record<string, object>): UndoPlan {
+  const plan: UndoPlan = new Map();
   for (const [operator, payload] of Object.entries(operations)) {
-    for (const [path, target] of Object.entries(payload as Record<string, unknown>)) {
-      captureRoot(originals, raw, path);
+    for (const [path, operand] of Object.entries(payload as Record<string, unknown>)) {
+      planPath(plan, raw, operator, path, operand);
       if (operator === "$rename") {
-        captureRoot(originals, raw, target as string);
+        // The destination is written like a $set.
+        planPath(plan, raw, "$set", operand as string);
       }
     }
   }
-  return originals;
+  return plan;
 }
 
-function captureRoot(originals: Originals, raw: object, path: string): void {
-  const root = path.split(".")[0]!;
-  if (!originals.has(root)) {
-    originals.set(
-      root,
-      Object.hasOwn(raw, root)
-        ? { present: true, value: cloneValue((raw as Record<string, unknown>)[root]) }
-        : { present: false },
-    );
+// `$` / `$[]` / `$[id]` — which element these resolve to is decided mid-apply,
+// so the containing array is saved whole rather than guessed at.
+function isPositionalSegment(segment: string): boolean {
+  return segment === "$" || segment.startsWith("$[");
+}
+
+// A $push whose spec can only append at the tail (no reordering modifiers);
+// $addToSet always appends at the tail.
+function isTailAppend(operator: string, operand: unknown): boolean {
+  if (operator === "$addToSet") {
+    return true;
+  }
+  return (
+    operator === "$push" &&
+    !(isObject(operand) && ("$position" in operand || "$sort" in operand || "$slice" in operand))
+  );
+}
+
+function planPath(
+  plan: UndoPlan,
+  raw: object,
+  operator: string,
+  path: string,
+  operand?: unknown,
+): void {
+  const parts = splitPath(path);
+  let current: any = raw;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const segment = parts[i]!;
+    if (isPositionalSegment(segment)) {
+      if (i > 0) {
+        addValueSpot(plan, raw, parts.slice(0, i).join("."), current);
+      }
+      return; // a positional segment at the root is invalid — the op throws
+    }
+    // Writing through an out-of-bounds index pads the array's tail; its
+    // original length is all an undo needs.
+    if (Array.isArray(current) && isArrayIndex(segment) && Number(segment) >= current.length) {
+      addSpot(plan, raw, {
+        kind: "length",
+        path: parts.slice(0, i).join("."),
+        length: current.length,
+      });
+      return;
+    }
+    if (
+      !isContainer(current) ||
+      !Object.hasOwn(current, segment) ||
+      !isContainer((current as any)[segment])
+    ) {
+      const prefix = parts.slice(0, i + 1).join(".");
+      if (isContainer(current) && Object.hasOwn(current, segment)) {
+        // A non-container value (e.g. null) about to be overwritten by a
+        // created branch — save it so undo restores it exactly.
+        addValueSpot(plan, raw, prefix, (current as any)[segment]);
+      } else {
+        addSpot(plan, raw, { kind: "absent", path: prefix });
+      }
+      return;
+    }
+    current = (current as any)[segment];
+  }
+
+  const leaf = parts[parts.length - 1]!;
+  if (isPositionalSegment(leaf)) {
+    if (parts.length > 1) {
+      addValueSpot(plan, raw, parts.slice(0, -1).join("."), current);
+    }
+    return;
+  }
+  // Same past-the-end rule at the leaf.
+  if (
+    Array.isArray(current) &&
+    isArrayIndex(leaf) &&
+    Number(leaf) >= current.length &&
+    parts.length > 1
+  ) {
+    addSpot(plan, raw, {
+      kind: "length",
+      path: parts.slice(0, -1).join("."),
+      length: current.length,
+    });
+    return;
+  }
+
+  const present = Object.hasOwn(current, leaf);
+  const leafValue = present ? (current as any)[leaf] : undefined;
+
+  if (Array.isArray(leafValue) && isTailAppend(operator, operand)) {
+    addSpot(plan, raw, { kind: "length", path, length: leafValue.length });
+    return;
+  }
+  if (Array.isArray(leafValue) && operator === "$pop" && operand === 1) {
+    // Only the popped element is at stake.
+    if (leafValue.length > 0) {
+      const last = leafValue.length - 1;
+      addValueSpot(plan, raw, `${path}.${last}`, leafValue[last]);
+    }
+    return;
+  }
+
+  if (present) {
+    addValueSpot(plan, raw, path, leafValue);
+  } else {
+    addSpot(plan, raw, { kind: "absent", path });
+  }
+}
+
+function addValueSpot(plan: UndoPlan, raw: object, path: string, value: unknown): void {
+  addSpot(plan, raw, { kind: "value", path, value: cloneValue(value) });
+}
+
+// Insert a spot, keeping the plan pairwise non-nested: a spot covered by an
+// existing one is redundant (both were read from the pristine document), and
+// nesting between spots collapses to a full `value` at the shallower path —
+// the one case this arises is interior writes plus growth on the same array,
+// where the undo inherently needs the whole prior array.
+function addSpot(plan: UndoPlan, raw: object, spot: Spot): void {
+  if (plan.has(spot.path)) {
+    return;
+  }
+  for (const other of plan.values()) {
+    if (pathCovers(other.path, spot.path)) {
+      widenToValue(plan, raw, other);
+      return;
+    }
+  }
+  let coversExisting = false;
+  for (const other of plan.values()) {
+    if (pathCovers(spot.path, other.path)) {
+      plan.delete(other.path);
+      coversExisting = true;
+    }
+  }
+  plan.set(spot.path, spot);
+  if (coversExisting) {
+    widenToValue(plan, raw, spot);
+  }
+}
+
+function widenToValue(plan: UndoPlan, raw: object, spot: Spot): void {
+  if (spot.kind === "length") {
+    plan.set(spot.path, {
+      kind: "value",
+      path: spot.path,
+      value: cloneValue(getValueAtPath(raw, spot.path)),
+    });
   }
 }
 
 type UndoDocument = Record<string, Record<string, unknown>>;
 
-/** Compare the mutated document against the originals and emit the undo. */
-export function buildUndo(raw: object, originals: Originals): UndoDocument {
+/** Compare each planned spot against the mutated document and emit the undo. */
+export function buildUndo(raw: object, plan: UndoPlan): UndoDocument {
   const undo: UndoDocument = {};
-  for (const [root, original] of originals) {
-    const present = Object.hasOwn(raw, root);
-    if (!original.present) {
-      if (present) {
-        unset(undo, root);
+  for (const spot of plan.values()) {
+    if (spot.kind === "absent") {
+      if (hasValueAtPath(raw, spot.path)) {
+        unset(undo, spot.path);
       }
-    } else if (present) {
-      restore(undo, root, original.value, (raw as Record<string, unknown>)[root]);
+    } else if (spot.kind === "length") {
+      const arr = getValueAtPath(raw, spot.path) as Array<unknown>;
+      if (arr.length === spot.length + 1) {
+        (undo["$pop"] ??= {})[spot.path] = 1;
+      } else if (arr.length > spot.length) {
+        (undo["$push"] ??= {})[spot.path] = { $each: [], $slice: spot.length };
+      }
+    } else if (hasValueAtPath(raw, spot.path)) {
+      restore(undo, spot.path, spot.value, getValueAtPath(raw, spot.path));
     } else {
-      set(undo, root, original.value);
+      restoreRemoved(undo, raw, spot.path, spot.value);
     }
   }
   return undo;
+}
+
+// A saved value whose path no longer exists. A removed tail element (its index
+// equals the array's current length) re-appends with $push; everything else is
+// $set back.
+function restoreRemoved(undo: UndoDocument, raw: object, path: string, value: unknown): void {
+  const parts = splitPath(path);
+  const leaf = parts[parts.length - 1]!;
+  if (isArrayIndex(leaf) && parts.length > 1) {
+    const parent = getValueAtPath(raw, parts.slice(0, -1).join("."));
+    if (Array.isArray(parent) && parent.length === Number(leaf)) {
+      (undo["$push"] ??= {})[path.slice(0, path.length - leaf.length - 1)] = value;
+      return;
+    }
+  }
+  set(undo, path, value);
 }
 
 function set(undo: UndoDocument, path: string, value: unknown): void {

--- a/packages/mill/tests/operators/combinations.test.ts
+++ b/packages/mill/tests/operators/combinations.test.ts
@@ -8,8 +8,8 @@ describe("MongoDB Style Operators", () => {
     const state = createReactive<any>({ a: [{ b: 1 }] });
     const { undo, rewindAndAssertRestored } = applyWithUndo(state, {}, { $set: { "a.5.c": 2 } });
     expect(state.a).toEqual([{ b: 1 }, null, null, null, null, { c: 2 }]);
-    // Growing the array can only be inverted by restoring the whole prior array.
-    expect(undo).toEqual({ $set: { a: [{ b: 1 }] } });
+    // Growth pads the tail, so truncating back to the prior length inverts it.
+    expect(undo).toEqual({ $push: { a: { $each: [], $slice: 1 } } });
     rewindAndAssertRestored();
   });
 

--- a/packages/mill/tests/operators/set.test.ts
+++ b/packages/mill/tests/operators/set.test.ts
@@ -1,6 +1,7 @@
 import { createReactive, effect } from "@supergrain/kernel";
 import { describe, it, expect, vi } from "vitest";
 
+import { update } from "../../src";
 import { applyWithUndo } from "../helpers";
 
 describe("MongoDB Style Operators", () => {
@@ -80,6 +81,16 @@ describe("MongoDB Style Operators", () => {
     const { rewindAndAssertRestored } = applyWithUndo(store, {}, { $set: { "items.1": 20 } });
     expect(store.items).toEqual([1, 20, 3]);
     rewindAndAssertRestored();
+  });
+
+  it("$set rejects a non-index field on an array, like MongoDB", () => {
+    const store = createReactive<any>({ b: [1, 2] });
+    expect(() => update(store, {}, { $set: { "b.c": 3 } })).toThrow(
+      "Cannot create field 'c' in element {b: [1,2]}.",
+    );
+    expect(() => update(store, {}, { $set: { "b.c.d": 3 } })).toThrow(
+      "Cannot create field 'c' in element {b: [1,2]}.",
+    );
   });
 
   it("$set fires effects subscribed to the written path and not to siblings", () => {

--- a/packages/mill/tests/operators/set.test.ts
+++ b/packages/mill/tests/operators/set.test.ts
@@ -93,6 +93,16 @@ describe("MongoDB Style Operators", () => {
     );
   });
 
+  it("$set rejects a non-index field when the document root is an array", () => {
+    const doc: any = [1, 2];
+    expect(() => update(doc, {}, { $set: { c: 3 } })).toThrow(
+      "Cannot create field 'c' in element [1,2].",
+    );
+    expect(() => update(doc, {}, { $set: { "c.d": 3 } })).toThrow(
+      "Cannot create field 'c' in element [1,2].",
+    );
+  });
+
   it("$set fires effects subscribed to the written path and not to siblings", () => {
     const store = createReactive({ a: 1, b: 2 });
     const aFn = vi.fn(() => void store.a);

--- a/packages/mill/tests/property.test.ts
+++ b/packages/mill/tests/property.test.ts
@@ -4,6 +4,7 @@ import { match } from "ts-pattern";
 import { describe, expect, it } from "vitest";
 
 import { update } from "../src";
+import { pathsConflict } from "../src/path";
 import { recordedUpdate } from "./helpers";
 
 interface MillState {
@@ -362,6 +363,137 @@ describe("property-based undo round-trip", () => {
         }
       }),
       { numRuns: 100 },
+    );
+  });
+});
+
+// ─── multi-path undo round-trip ──────────────────────────────────────────────
+//
+// Single-path updates can never make undo entries interact. The failure family
+// this hunts is several disjoint update paths whose *undo* paths collide:
+// branches the update itself creates, out-of-bounds array growth, and every
+// ordering of the two. For any legal combination, the generated undo must
+// itself be a legal update document (replaying must not throw) and replaying
+// it must restore the exact prior document.
+
+const pathKeyArbitrary = fc.constantFrom("a", "b", "c");
+const pathSegmentArbitrary = fc.oneof(pathKeyArbitrary, fc.constantFrom("0", "1", "5"));
+const pathArbitrary = fc
+  .array(pathSegmentArbitrary, { minLength: 1, maxLength: 3 })
+  .map((segments) => segments.join("."));
+
+// JSON-ish values/documents over the same tiny key alphabet, so generated
+// paths sometimes traverse existing structure and sometimes create it.
+const { value: valueArbitrary } = fc.letrec((tie) => ({
+  value: fc.oneof(
+    { depthSize: "small", withCrossShrink: true },
+    integerArbitrary,
+    fc.array(tie("value"), { maxLength: 3 }),
+    fc.dictionary(pathKeyArbitrary, tie("value"), { maxKeys: 2 }),
+  ),
+}));
+const documentArbitrary = fc.dictionary(pathKeyArbitrary, valueArbitrary, { maxKeys: 3 });
+
+// Keep only mutually non-conflicting paths — mill (like Mongo) rejects
+// conflicting forward paths up front, which is not the behavior under test.
+function keepNonConflicting(paths: ReadonlyArray<string>): Array<string> {
+  const kept: Array<string> = [];
+  for (const path of paths) {
+    if (kept.every((existing) => !pathsConflict(existing, path))) {
+      kept.push(path);
+    }
+  }
+  return kept;
+}
+
+type MultiPathOperation = { op: "$set"; value: unknown } | { op: "$unset" };
+const multiPathOperationArbitrary: fc.Arbitrary<MultiPathOperation> = fc.oneof(
+  valueArbitrary.map((value) => ({ op: "$set", value }) as MultiPathOperation),
+  fc.constant<MultiPathOperation>({ op: "$unset" }),
+);
+
+// A $set/$unset update document over a non-conflicting subset of paths drawn
+// from `candidatePathArbitrary`, in random order.
+function multiPathUpdateArbitrary(
+  candidatePathArbitrary: fc.Arbitrary<string>,
+): fc.Arbitrary<Record<string, Record<string, unknown>>> {
+  return fc
+    .uniqueArray(candidatePathArbitrary, { minLength: 1, maxLength: 4 })
+    .map(keepNonConflicting)
+    .chain((paths) =>
+      fc
+        .array(multiPathOperationArbitrary, { minLength: paths.length, maxLength: paths.length })
+        .map((operations) => {
+          const ops: Record<string, Record<string, unknown>> = {};
+          paths.forEach((path, index) => {
+            const operation = operations[index]!;
+            (ops[operation.op] ??= {})[path] = operation.op === "$set" ? operation.value : 1;
+          });
+          return ops;
+        }),
+    );
+}
+
+function assertUndoRoundTrips(
+  initial: Record<string, unknown>,
+  ops: Record<string, Record<string, unknown>>,
+): void {
+  const store = createReactive<Record<string, unknown>>(structuredClone(initial));
+  let undo: Record<string, unknown>;
+  try {
+    ({ undo } = recordedUpdate(store, {}, ops as never) as {
+      undo: Record<string, unknown>;
+    });
+  } catch {
+    // Updates this document's shape rejects (a path through a scalar or null)
+    // throw in mill exactly as in Mongo — not the property under test.
+    return;
+  }
+  update(store, {}, undo as never);
+  expect(unwrap(store)).toEqual(initial);
+}
+
+describe("property-based undo round-trip — multi-path updates", () => {
+  it("undo is always replayable and restores the exact prior document", () => {
+    fc.assert(
+      fc.property(documentArbitrary, multiPathUpdateArbitrary(pathArbitrary), (initial, ops) => {
+        assertUndoRoundTrips(initial, ops);
+      }),
+      { numRuns: 300 },
+    );
+  });
+
+  // Focused variant of the same property: sibling index writes on one array,
+  // in and out of bounds, in every order. This is the shape where an
+  // out-of-bounds write escalates to a whole-array restore that must absorb
+  // (not conflict with) undo entries already recorded beneath it.
+  it("sibling index writes on one array — in and out of bounds", () => {
+    const elementArbitrary = fc.oneof(
+      integerArbitrary,
+      fc.record({ t: fc.array(integerArbitrary, { maxLength: 2 }) }),
+    );
+    const arrayDocumentArbitrary = fc
+      .array(elementArbitrary, { maxLength: 4 })
+      .map((arr) => ({ arr }) as Record<string, unknown>);
+    const arrayPathArbitrary = fc.constantFrom(
+      "arr.0",
+      "arr.1",
+      "arr.2",
+      "arr.5",
+      "arr.8",
+      "arr.0.t",
+      "arr.1.t.0",
+      "arr.5.t",
+    );
+    fc.assert(
+      fc.property(
+        arrayDocumentArbitrary,
+        multiPathUpdateArbitrary(arrayPathArbitrary),
+        (initial, ops) => {
+          assertUndoRoundTrips(initial, ops);
+        },
+      ),
+      { numRuns: 300 },
     );
   });
 });

--- a/packages/mill/tests/undo.test.ts
+++ b/packages/mill/tests/undo.test.ts
@@ -206,3 +206,66 @@ describe("undo — sibling writes under a created branch stay conflict-free", ()
     expect(unwrap(store)).toEqual(initial);
   });
 });
+
+// The covering entry doesn't always come first: an out-of-bounds index write
+// forces a whole-array restore that can arrive *after* granular entries under
+// the same array. The stale snapshot (earlier ops already wrote into it) must
+// absorb those entries, not conflict with them.
+describe("undo — whole-array snapshots arriving after granular entries", () => {
+  it("in-bounds write, then out-of-bounds growth of the same array", () => {
+    const { undo } = roundTrip({ arr: [10, 20, 30] } as Record<string, unknown>, {
+      $set: { "arr.2": 99, "arr.5": 77 },
+    });
+    expect(undo).toEqual({ $set: { arr: [10, 20, 30] } });
+  });
+
+  it("out-of-bounds growth, then in-bounds write (covering entry first)", () => {
+    const { undo } = roundTrip({ arr: [10, 20, 30] } as Record<string, unknown>, {
+      $set: { "arr.5": 77, "arr.2": 99 },
+    });
+    expect(undo).toEqual({ $set: { arr: [10, 20, 30] } });
+  });
+
+  it("two out-of-bounds writes collapse to one snapshot", () => {
+    const { undo } = roundTrip({ arr: [1] } as Record<string, unknown>, {
+      $set: { "arr.3": 7, "arr.6": 8 },
+    });
+    expect(undo).toEqual({ $set: { arr: [1] } });
+  });
+
+  it("absorbs a write nested inside an element", () => {
+    const { undo } = roundTrip({ arr: [{ t: [1, 2] }] } as Record<string, unknown>, {
+      $set: { "arr.0.t.1": 9, "arr.5": 3 },
+    });
+    expect(undo).toEqual({ $set: { arr: [{ t: [1, 2] }] } });
+  });
+
+  it("absorbs a granular array inverse inside an element", () => {
+    const { undo } = roundTrip({ arr: [{ t: [1, 2] }] } as Record<string, unknown>, {
+      $pull: { "arr.0.t": 2 },
+      $push: { "arr.3": 9 },
+    });
+    expect(undo).toEqual({ $set: { arr: [{ t: [1, 2] }] } });
+  });
+
+  it("growth through an out-of-bounds *intermediate* index absorbs too", () => {
+    const { undo } = roundTrip({ arr: [{ t: 1 }] } as Record<string, unknown>, {
+      $set: { "arr.0.t": 2, "arr.4.u": 3 },
+    });
+    expect(undo).toEqual({ $set: { arr: [{ t: 1 }] } });
+  });
+
+  it("a scattered $pull on a nested array restores the outer array", () => {
+    const { undo } = roundTrip({ arr: [{ t: [1, 2, 3] }] } as Record<string, unknown>, {
+      $pull: { "arr.0.t": { $in: [1, 3] } },
+    });
+    expect(undo).toEqual({ $set: { arr: [{ t: [1, 2, 3] }] } });
+  });
+
+  it("absorbs an $unset entry (a field the update created inside an element)", () => {
+    const { undo } = roundTrip({ arr: [{}] } as Record<string, unknown>, {
+      $set: { "arr.0.x": 1, "arr.5": 2 },
+    });
+    expect(undo).toEqual({ $set: { arr: [{}] } });
+  });
+});

--- a/packages/mill/tests/undo.test.ts
+++ b/packages/mill/tests/undo.test.ts
@@ -153,3 +153,56 @@ describe("undo — no-ops produce no undo", () => {
     expect(undo).toEqual({});
   });
 });
+
+// The undo document must itself be a legal update document. When several paths
+// share a branch the update has to create, the first one captures the whole
+// missing branch and the rest are redundant — emitting them anyway produced an
+// undo that `update()` refused to replay ("would create a conflict between
+// paths ...").
+describe("undo — sibling writes under a created branch stay conflict-free", () => {
+  it("collapses to the created branch for two $set siblings", () => {
+    const { undo } = roundTrip({} as Record<string, unknown>, {
+      $set: { "rel.course": { id: "c1" }, "rel.planbook": { id: "p1" } },
+    });
+    expect(undo).toEqual({ $unset: { rel: "" } });
+  });
+
+  it("collapses across a deeper shared branch", () => {
+    const { undo } = roundTrip({ a: {} } as Record<string, unknown>, {
+      $set: { "a.b.c": 1, "a.b.d": 2 },
+    });
+    expect(undo).toEqual({ $unset: { "a.b": "" } });
+  });
+
+  it("collapses across different operators", () => {
+    const { undo } = roundTrip({} as Record<string, unknown>, {
+      $set: { "rel.course": { id: "c1" } },
+      $inc: { "rel.count": 2 },
+      $push: { "rel.tags": "x" },
+    });
+    expect(undo).toEqual({ $unset: { rel: "" } });
+  });
+
+  it("keeps siblings that do not share a created branch", () => {
+    const { undo } = roundTrip({ rel: {} } as Record<string, unknown>, {
+      $set: { "rel.course": { id: "c1" }, "rel.planbook": { id: "p1" } },
+    });
+    expect(undo).toEqual({ $unset: { "rel.course": "", "rel.planbook": "" } });
+  });
+
+  it("collapses to a null intermediate under allowNullIntermediates", () => {
+    const initial = { rel: null } as Record<string, unknown>;
+    const store = createReactive(structuredClone(initial));
+
+    const { undo } = update(
+      store,
+      {},
+      { $set: { "rel.course": { id: "c1" }, "rel.planbook": { id: "p1" } } },
+      { allowNullIntermediates: true },
+    );
+    expect(undo).toEqual({ $set: { rel: null } });
+
+    update(store, {}, undo, { allowNullIntermediates: true });
+    expect(unwrap(store)).toEqual(initial);
+  });
+});

--- a/packages/mill/tests/undo.test.ts
+++ b/packages/mill/tests/undo.test.ts
@@ -269,15 +269,42 @@ describe("undo — whole-array snapshots arriving after granular entries", () =>
     expect(undo).toEqual({ $set: { arr: [{}] } });
   });
 
-  // Mongo paths can't name a key that is empty or contains a dot, so an object
-  // holding one can only be restored wholesale. Plain update() here — the
-  // mongod oracle's tolerance for dotted keys varies by server version.
-  it("an object holding a dotted key restores wholesale", () => {
-    const initial = { a: { "x.y": 1, b: 2 } } as Record<string, unknown>;
+  it("a positional write alongside an index write restores both", () => {
+    const initial = { items: [{ k: 1, x: 0, y: 0 }] } as Record<string, unknown>;
     const store = createReactive(structuredClone(initial));
-    const { undo } = update(store, {}, { $set: { "a.b": 3 } });
-    expect(undo).toEqual({ $set: { a: { "x.y": 1, b: 2 } } });
+    const { undo } = update(
+      store,
+      { "items.k": 1 } as never,
+      { $set: { "items.$.x": 5, "items.0.y": 6 } } as never,
+    );
     update(store, {}, undo);
     expect(unwrap(store)).toEqual(initial);
+  });
+
+  it("rejects a positional segment at the document root", () => {
+    const store = createReactive<Record<string, unknown>>({ a: 1 });
+    expect(() => update(store, {}, { $set: { "$.x": 1 } } as never)).toThrow();
+    expect(() => update(store, {}, { $set: { $: 1 } } as never)).toThrow();
+  });
+
+  // Mongo paths can't name a key that is empty or contains a dot. A write at a
+  // sibling path restores just itself; replacing the whole object restores it
+  // wholesale rather than descending into the unaddressable key. Plain
+  // update() here — the mongod oracle's tolerance for dotted keys varies by
+  // server version.
+  it("dotted keys: sibling writes restore precisely, replacements wholesale", () => {
+    const initial = { a: { "x.y": 1, b: 2 } } as Record<string, unknown>;
+
+    const sibling = createReactive(structuredClone(initial));
+    const { undo: siblingUndo } = update(sibling, {}, { $set: { "a.b": 3 } });
+    expect(siblingUndo).toEqual({ $set: { "a.b": 2 } });
+    update(sibling, {}, siblingUndo);
+    expect(unwrap(sibling)).toEqual(initial);
+
+    const replaced = createReactive(structuredClone(initial));
+    const { undo: replacedUndo } = update(replaced, {}, { $set: { a: { b: 9 } } });
+    expect(replacedUndo).toEqual({ $set: { a: { "x.y": 1, b: 2 } } });
+    update(replaced, {}, replacedUndo);
+    expect(unwrap(replaced)).toEqual(initial);
   });
 });

--- a/packages/mill/tests/undo.test.ts
+++ b/packages/mill/tests/undo.test.ts
@@ -226,11 +226,11 @@ describe("undo — whole-array snapshots arriving after granular entries", () =>
     expect(undo).toEqual({ $set: { arr: [10, 20, 30] } });
   });
 
-  it("two out-of-bounds writes collapse to one snapshot", () => {
+  it("two out-of-bounds writes undo with one truncation", () => {
     const { undo } = roundTrip({ arr: [1] } as Record<string, unknown>, {
       $set: { "arr.3": 7, "arr.6": 8 },
     });
-    expect(undo).toEqual({ $set: { arr: [1] } });
+    expect(undo).toEqual({ $push: { arr: { $each: [], $slice: 1 } } });
   });
 
   it("absorbs a write nested inside an element", () => {
@@ -255,17 +255,29 @@ describe("undo — whole-array snapshots arriving after granular entries", () =>
     expect(undo).toEqual({ $set: { arr: [{ t: 1 }] } });
   });
 
-  it("a scattered $pull on a nested array restores the outer array", () => {
+  it("a scattered $pull on a nested array restores that array precisely", () => {
     const { undo } = roundTrip({ arr: [{ t: [1, 2, 3] }] } as Record<string, unknown>, {
       $pull: { "arr.0.t": { $in: [1, 3] } },
     });
-    expect(undo).toEqual({ $set: { arr: [{ t: [1, 2, 3] }] } });
+    expect(undo).toEqual({ $set: { "arr.0.t": [1, 2, 3] } });
   });
 
-  it("absorbs an $unset entry (a field the update created inside an element)", () => {
+  it("a field created inside an element restores with the whole array", () => {
     const { undo } = roundTrip({ arr: [{}] } as Record<string, unknown>, {
       $set: { "arr.0.x": 1, "arr.5": 2 },
     });
     expect(undo).toEqual({ $set: { arr: [{}] } });
+  });
+
+  // Mongo paths can't name a key that is empty or contains a dot, so an object
+  // holding one can only be restored wholesale. Plain update() here — the
+  // mongod oracle's tolerance for dotted keys varies by server version.
+  it("an object holding a dotted key restores wholesale", () => {
+    const initial = { a: { "x.y": 1, b: 2 } } as Record<string, unknown>;
+    const store = createReactive(structuredClone(initial));
+    const { undo } = update(store, {}, { $set: { "a.b": 3 } });
+    expect(undo).toEqual({ $set: { a: { "x.y": 1, b: 2 } } });
+    update(store, {}, undo);
+    expect(unwrap(store)).toEqual(initial);
   });
 });


### PR DESCRIPTION
## The problem

Every `update()` returns an `undo` — a Mongo update document that puts the document back the way it was. For some updates, the undo we generated was invalid and threw when applied.

Example: on a document with no `rel` field,

```ts
update(store, {}, { $set: { "rel.course": c, "rel.planbook": p } });
```

generated `{ $unset: { rel: "", "rel.planbook": "" } }`. Mongo rejects any update where one path contains another (`rel` and `rel.planbook`), so replaying this undo threw instead of rolling back. The same thing happened when one update wrote both inside an array and past its end (`{ $set: { "arr.2": x, "arr.5": y } }`) — and in that case the undo also captured wrong values.

## The fix

The root cause was *how* undo was built: every operator (`$set`, `$push`, `$pull`, …) recorded its own inverse while it mutated, and those separately-recorded pieces could contradict each other. This PR moves undo out of the operators entirely:

1. **Before applying anything**, look at the update's paths and save the smallest thing needed to reverse each one: the value about to be overwritten, a note that a field doesn't exist yet, or — for appends and past-the-end writes — just the array's current length (undoing those is simply "cut the array back", so appending to a 10,000-item list saves one number, not 10,000 items).
2. **Apply the update.**
3. **Afterwards**, compare each saved piece with the result and emit the undo.

Because everything is saved up front from the untouched document, the values are always right; and because the saved pieces are kept from overlapping, the undo can never contain the conflicting paths Mongo rejects.

**This is why the PR deletes so much code.** Undo knowledge used to be spread across all twelve operators — each one carried recording calls, in a specific order relative to its mutations, plus shared machinery trying to keep the recorded pieces consistent with each other. All of that is gone: the operators now just mutate, and reversal lives in one place that never needs to know which operator did the writing. The whole class of "recorded pieces disagree" bugs goes with it — there's nothing left to disagree.

## Also in here

- `$set: { "b.c": 1 }` where `b` is an array now throws like real MongoDB, instead of silently putting a string key on the array (found while testing this change).
- New randomized tests that apply many-path updates and verify every undo replays cleanly and restores the document exactly, validated against a real mongod. The changed files are at 100% test coverage.