### PR TITLE
fix(mill): $inc/$mul/$min/$max treat a null target as absent under allowNullIntermediates

### DIFF
--- a/.changeset/mill-numeric-null-target.md
+++ b/.changeset/mill-numeric-null-target.md
@@ -12,4 +12,4 @@ With `allowNullIntermediates: true`, a `null` target is now treated as a missing
 - `$mul` starts from 0, yielding `0`.
 - `$min` / `$max` take the operand instead of keeping the `null`.
 
-Default behavior is unchanged: with the option off, mill still rejects a `null` numeric target exactly as MongoDB does. The generated `undo` restores the prior `null`.
+Default behavior is unchanged: with the option off, `$inc` / `$mul` still reject a `null` target, and `$min` / `$max` still compare against it as a value sorting below every number — exactly as MongoDB does. The generated `undo` restores the prior `null`.

--- a/.changeset/mill-numeric-null-target.md
+++ b/.changeset/mill-numeric-null-target.md
@@ -1,0 +1,15 @@
+---
+"@supergrain/mill": patch
+---
+
+Fix `allowNullIntermediates` so a `null` _target_ of a numeric operator counts as absent.
+
+`allowNullIntermediates` is documented as treating a `null` intermediate **or target** as if the field were absent, but the numeric operators only honored that for intermediates: `$inc`-ing a `null` field still threw `$inc path "attributes._revision" must point to a number, received null.` even with the option on. That defeats the option's purpose — it exists so patches that work against MongoDB (where the field is genuinely absent) also work against documents where the absent field arrived as `null`.
+
+With `allowNullIntermediates: true`, a `null` target is now treated as a missing field:
+
+- `$inc` starts from 0, so `{ a: null }` + `$inc: { a: 1 }` yields `{ a: 1 }`.
+- `$mul` starts from 0, yielding `0`.
+- `$min` / `$max` take the operand instead of keeping the `null`.
+
+Default behavior is unchanged: with the option off, mill still rejects a `null` numeric target exactly as MongoDB does. The generated `undo` restores the prior `null`.

--- a/packages/mill/README.md
+++ b/packages/mill/README.md
@@ -97,6 +97,7 @@ update(doc, {}, { $push: { "attributes.cards": { id: "x" } } }, { allowNullInter
 ```
 
 - `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects over `null` intermediates.
+- `$inc` / `$mul` / `$min` / `$max` treat a `null` **target** as a missing field rather than a type error — `$inc` starts from 0, `$mul` yields 0, `$min` / `$max` take the operand.
 - `$push` / `$addToSet` create the array when the target (or an intermediate) is `null`.
 - `$pull` / `$pullAll` / `$pop` no-op on a `null` target, exactly as they do for a missing field.
 

--- a/packages/mill/README.md
+++ b/packages/mill/README.md
@@ -97,7 +97,7 @@ update(doc, {}, { $push: { "attributes.cards": { id: "x" } } }, { allowNullInter
 ```
 
 - `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects over `null` intermediates.
-- `$inc` / `$mul` / `$min` / `$max` treat a `null` **target** as a missing field rather than a type error — `$inc` starts from 0, `$mul` yields 0, `$min` / `$max` take the operand.
+- `$inc` / `$mul` / `$min` / `$max` treat a `null` **target** as absent: `$inc` starts from 0 and `$mul` yields 0 rather than throwing, while `$min` / `$max` take the operand instead of sorting against the `null`.
 - `$push` / `$addToSet` create the array when the target (or an intermediate) is `null`.
 - `$pull` / `$pullAll` / `$pop` no-op on a `null` target, exactly as they do for a missing field.
 

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -142,9 +142,9 @@ export interface UpdateOptions {
    *
    *   - `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects
    *     over `null` intermediates instead of throwing.
-   *   - `$inc` / `$mul` / `$min` / `$max` treat a `null` *target* as a missing
-   *     field instead of a type error: `$inc` starts from 0, `$mul` yields 0,
-   *     `$min` / `$max` take the operand.
+   *   - `$inc` / `$mul` / `$min` / `$max` treat a `null` *target* as absent:
+   *     `$inc` starts from 0 and `$mul` yields 0 rather than throwing, while
+   *     `$min` / `$max` take the operand instead of sorting against the `null`.
    *   - `$push` / `$addToSet` create the array when the target (or an
    *     intermediate) is `null`.
    *   - `$pull` / `$pullAll` / `$pop` no-op on a `null` target (exactly as they

--- a/packages/mill/src/operators.ts
+++ b/packages/mill/src/operators.ts
@@ -142,6 +142,9 @@ export interface UpdateOptions {
    *
    *   - `$set` / `$inc` / `$mul` / `$min` / `$max` / `$rename` build objects
    *     over `null` intermediates instead of throwing.
+   *   - `$inc` / `$mul` / `$min` / `$max` treat a `null` *target* as a missing
+   *     field instead of a type error: `$inc` starts from 0, `$mul` yields 0,
+   *     `$min` / `$max` take the operand.
    *   - `$push` / `$addToSet` create the array when the target (or an
    *     intermediate) is `null`.
    *   - `$pull` / `$pullAll` / `$pop` no-op on a `null` target (exactly as they

--- a/packages/mill/src/operators/shared.ts
+++ b/packages/mill/src/operators/shared.ts
@@ -50,6 +50,8 @@ function assertNumericTarget(
 ): void {
   // $min/$max compare against an existing null (it sorts below every number);
   // $inc/$mul reject it the way real MongoDB does ("non-numeric type null").
+  // Only reachable for a stored null — `allowNullIntermediates` normalizes those
+  // to `undefined` (absent) before we get here.
   if (currentValue === null && allowNull) {
     return;
   }
@@ -68,7 +70,13 @@ export interface NumericWrite {
 }
 
 export function writeNumeric(context: OperatorContext, path: string, write: NumericWrite): void {
-  const previous = getValueAtPath(context.raw, path) as number | null | undefined;
+  const stored = getValueAtPath(context.raw, path) as number | null | undefined;
+  // With `allowNullIntermediates`, a `null` *target* counts as absent just like a
+  // `null` intermediate does: $inc/$mul start from 0 instead of throwing, and
+  // $min/$max take the candidate value rather than keeping the null. Only the
+  // arithmetic treats it as absent — the undo plan snapshots the real stored
+  // `null` before we run, so a rewind restores it exactly.
+  const previous = context.allowNullIntermediates && stored === null ? undefined : stored;
   assertNumericTarget(write.operator, path, previous, write.allowNull);
   const next = write.compute(previous);
   if (next === undefined) {

--- a/packages/mill/tests/operators/allow-null-intermediates.test.ts
+++ b/packages/mill/tests/operators/allow-null-intermediates.test.ts
@@ -65,6 +65,55 @@ describe("allowNullIntermediates", () => {
     });
   });
 
+  it("$inc starts from 0 when the target is null", () => {
+    const store = createReactive<any>({ attributes: { _revision: null } });
+    expectRoundTrip(store, { $inc: { "attributes._revision": 1 } }, () => {
+      expect(store.attributes._revision).toBe(1);
+    });
+  });
+
+  it("$inc from a null target handles a negative delta and a zero delta", () => {
+    const decrement = createReactive<any>({ n: null });
+    expectRoundTrip(decrement, { $inc: { n: -3 } }, () => {
+      expect(decrement.n).toBe(-3);
+    });
+
+    // `null + 0` still writes: the field goes from null to the number 0, exactly
+    // as $inc-ing an absent field by 0 creates it in MongoDB.
+    const zero = createReactive<any>({ n: null });
+    expectRoundTrip(zero, { $inc: { n: 0 } }, () => {
+      expect(zero.n).toBe(0);
+    });
+  });
+
+  it("$mul starts from 0 when the target is null", () => {
+    const store = createReactive<any>({ n: null });
+    expectRoundTrip(store, { $mul: { n: 4 } }, () => {
+      expect(store.n).toBe(0);
+    });
+  });
+
+  it("$min / $max take the candidate when the target is null", () => {
+    const min = createReactive<any>({ n: null });
+    expectRoundTrip(min, { $min: { n: 7 } }, () => {
+      expect(min.n).toBe(7);
+    });
+
+    const max = createReactive<any>({ n: null });
+    expectRoundTrip(max, { $max: { n: 7 } }, () => {
+      expect(max.n).toBe(7);
+    });
+  });
+
+  it("a null target is only absent for the operator that writes it", () => {
+    // The option doesn't make nulls disappear: an untouched null stays put.
+    const store = createReactive<any>({ touched: null, untouched: null });
+    expectRoundTrip(store, { $inc: { touched: 2 } }, () => {
+      expect(store.touched).toBe(2);
+      expect(store.untouched).toBe(null);
+    });
+  });
+
   it("$pull / $pullAll / $pop no-op on a null target (leaving the null in place)", () => {
     for (const ops of [
       { $pull: { items: 1 } },
@@ -94,5 +143,11 @@ describe("allowNullIntermediates", () => {
 
     const pushStore = createReactive<any>({ a: null });
     expect(() => update(pushStore, {}, { $push: { a: 1 } })).toThrow(/must point to an array/i);
+
+    const incStore = createReactive<any>({ a: null });
+    expect(() => update(incStore, {}, { $inc: { a: 1 } })).toThrow(/must point to a number/i);
+
+    const mulStore = createReactive<any>({ a: null });
+    expect(() => update(mulStore, {}, { $mul: { a: 2 } })).toThrow(/must point to a number/i);
   });
 });


### PR DESCRIPTION
Fixes `$inc path "attributes._revision" must point to a number, received null.` (Sentry V4-5GWW).

`allowNullIntermediates` is documented as treating a `null` intermediate **or target** as absent, but the numeric operators only honored it for intermediates — a `null` target still threw:

```ts
// { attributes: { _revision: null } }
update(doc, {}, { $inc: { "attributes._revision": 1 } }, { allowNullIntermediates: true }) // throws
```

That's the exact case the option exists for: Ecto turns absent Mongo fields into `nil`, so a patch that applies cleanly in MongoDB — field absent, `$inc` starts from 0 — blew up here.

`writeNumeric` now normalizes a stored `null` to `undefined` when the option is on, so all four numeric operators see the same "absent" they already see for a missing field:

- `$inc` starts from 0 — `{ a: null }` + `$inc: { a: 1 }` → `{ a: 1 }`
- `$mul` starts from 0, yielding `0`
- `$min` / `$max` take the operand instead of keeping the `null`

Only the arithmetic treats it as absent; undo still snapshots the real stored `null` and restores it.

Fixing it in the shared helper rather than special-casing `$inc` keeps `$mul` — which threw on the identical path — from staying broken.

**Default behavior is unchanged.** With the option off, mill still rejects a `null` numeric target the way MongoDB does; the oracle and rejection-parity suites are untouched.

Tests cover `$inc` / `$mul` / `$min` / `$max` from a `null` target (including the reported `attributes._revision` shape, a negative delta, and a zero delta), that an untouched sibling `null` stays `null`, and that the option-off path still throws. Each asserts the undo round-trip.